### PR TITLE
Integrate explore_lite from m-explore repo

### DIFF
--- a/Dockerfile.explore_lite
+++ b/Dockerfile.explore_lite
@@ -1,0 +1,28 @@
+FROM ros:humble-ros-base
+
+# Install tools needed for building the workspace
+RUN apt-get update && \
+    apt-get install -y git python3-colcon-common-extensions python3-rosdep && \
+    rm -rf /var/lib/apt/lists/*
+
+# Initialize rosdep
+RUN rosdep init && rosdep update || true
+
+# Create workspace
+WORKDIR /opt/explore_ws
+RUN mkdir src
+WORKDIR /opt/explore_ws/src
+
+# Clone the exploration package
+RUN git clone https://github.com/robo-friends/m-explore-ros2.git
+
+# Build the workspace
+WORKDIR /opt/explore_ws
+RUN . /opt/ros/humble/setup.sh && \
+    rosdep install --from-paths src --ignore-src -r -y && \
+    colcon build --symlink-install
+
+# Default command runs explore lite
+CMD bash -c "source /opt/ros/humble/setup.bash && \
+             source /opt/explore_ws/install/setup.bash && \
+             ros2 launch explore_lite explore.launch.py"

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Available recipes:
     sync hostname="${ROBOT_NAMESPACE}" password="husarion" # Copy repo content to remote host with 'rsync' and watch for changes
     flash-firmware     # flash the proper firmware for STM32 microcontroller in ROSbot XL
     start-rosbot       # start containers on a physical ROSbot XL
+    start              # same as 'start-rosbot'
     start-simulation engine="gazebo" # start the simulation (available options: gazebo, webots)
     restart-navigation # Restart the Nav2 container
 ```
@@ -109,8 +110,12 @@ To ensure proper user configuration, review the content of the `.env` file and s
 
    ```bash
    just start-rosbot
-   # or "just rosbot"
+   # or simply "just start" or "just rosbot"
    ```
+
+   The `explore_lite` node is built from the
+   [m-explore-ros2](https://github.com/robo-friends/m-explore-ros2) repository
+   and launches automatically with this command.
 
 ### 🚗 Step 5: Control the ROSbot from a Web Browser
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -61,16 +61,12 @@ services:
     restart: unless-stopped
     command: ros2 launch foxglove_bridge foxglove_bridge_launch.xml port:=8765 capabilities:=[clientPublish,connectionGraph,assets]
 
-  explore_lite:                        # ← misma columna que “foxglove-ds”
-    image: ros:humble-ros-base
+  explore_lite:
+    build:
+      context: .
+      dockerfile: Dockerfile.explore_lite
     network_mode: host
     restart: unless-stopped
-    command: >
-      bash -c "
-        apt update &&
-        apt install -y ros-humble-explore-lite &&
-        ros2 launch explore_lite explore.launch.py
-      "
     depends_on:
       navigation:
         condition: service_healthy

--- a/justfile
+++ b/justfile
@@ -10,6 +10,8 @@ alias husarnet := connect-husarnet
 alias flash := flash-firmware
 [private]
 alias rosbot := start-rosbot
+[private]
+alias start := start-rosbot
 
 [private]
 gazebo: (start-simulation "gazebo")


### PR DESCRIPTION
## Summary
- allow `just start` alias
- build `explore_lite` from the `m-explore-ros2` repository
- document the new alias and exploration node build steps

## Testing
- `pre-commit run --files README.md compose.yaml justfile Dockerfile.explore_lite` *(fails: `pre-commit: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6851ac697ab88323bdcca8767197564d