### PR TITLE
Fix apt update before rosdep in explore_lite Dockerfile

### DIFF
--- a/Dockerfile.explore_lite
+++ b/Dockerfile.explore_lite
@@ -19,7 +19,9 @@ RUN git clone https://github.com/robo-friends/m-explore-ros2.git
 # Build the workspace
 WORKDIR /opt/explore_ws
 RUN . /opt/ros/humble/setup.sh && \
+    apt-get update && \
     rosdep install --from-paths src --ignore-src -r -y && \
+    rm -rf /var/lib/apt/lists/* && \
     colcon build --symlink-install
 
 # Default command runs explore lite


### PR DESCRIPTION
## Summary
- ensure apt lists exist before rosdep install

## Testing
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851af1d1c1c832383868b9d59930ce3