### PR TITLE
Fix explore_lite build by installing Boost

### DIFF
--- a/Dockerfile.explore_lite
+++ b/Dockerfile.explore_lite
@@ -21,6 +21,7 @@ WORKDIR /opt/explore_ws
 RUN . /opt/ros/humble/setup.sh && \
     apt-get update && \
     rosdep install --from-paths src --ignore-src -r -y && \
+    apt-get install -y libboost-thread-dev && \
     rm -rf /var/lib/apt/lists/* && \
     colcon build --symlink-install
 


### PR DESCRIPTION
## Summary
- add Boost thread library to the Explore Lite image

## Testing
- `pre-commit` *(fails: could not install dependencies due to network)*

------
https://chatgpt.com/codex/tasks/task_e_6851b8585ee88323b599acc9ad953608