### PR TITLE
Allow custom explore_lite parameters

### DIFF
--- a/Dockerfile.explore_lite
+++ b/Dockerfile.explore_lite
@@ -25,7 +25,10 @@ RUN . /opt/ros/humble/setup.sh && \
     rm -rf /var/lib/apt/lists/* && \
     colcon build --symlink-install
 
-# Default command runs explore lite
+# Copy default parameters for explore_lite
+COPY config/explore_params.yaml /opt/explore_ws/
+
+# Default command runs explore lite with custom parameters
 CMD bash -c "source /opt/ros/humble/setup.bash && \
              source /opt/explore_ws/install/setup.bash && \
-             ros2 launch explore_lite explore.launch.py"
+             ros2 launch explore_lite explore.launch.py params_file:=/opt/explore_ws/explore_params.yaml"

--- a/README.md
+++ b/README.md
@@ -113,9 +113,14 @@ To ensure proper user configuration, review the content of the `.env` file and s
    # or simply "just start" or "just rosbot"
    ```
 
-   The `explore_lite` node is built from the
-   [m-explore-ros2](https://github.com/robo-friends/m-explore-ros2) repository
-   and launches automatically with this command.
+  The `explore_lite` node is built from the
+  [m-explore-ros2](https://github.com/robo-friends/m-explore-ros2) repository
+  and launches automatically with this command.
+
+   The parameters used by `explore_lite` are stored in
+   `config/explore_params.yaml`.  Edit this file to adjust options such as
+   `planner_frequency` or `progress_timeout` and restart the Compose stack to
+   apply the changes.
 
 ### 🚗 Step 5: Control the ROSbot from a Web Browser
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -67,6 +67,8 @@ services:
       dockerfile: Dockerfile.explore_lite
     network_mode: host
     restart: unless-stopped
+    volumes:
+      - ./config/explore_params.yaml:/opt/explore_ws/explore_params.yaml:ro
     depends_on:
       navigation:
         condition: service_healthy

--- a/config/explore_params.yaml
+++ b/config/explore_params.yaml
@@ -1,0 +1,2 @@
+planner_frequency: 0.1
+progress_timeout: 30.0


### PR DESCRIPTION
## Summary
- add explore_params.yaml to configure `explore_lite`
- copy params in `Dockerfile.explore_lite` and pass to launch
- mount the params file in `docker compose`
- document how to customize the parameters

## Testing
- `pip install pre-commit` *(fails: Could not find a version)*
- `pre-commit run -a` *(command not found)*
- `docker compose config` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852a9d40b3c8323ba27b707ce55e397