### PR TITLE
Fix start-rosbot using compose file only

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -14,7 +14,7 @@ services:
   # 2) Slam-Toolbox  (online_sync, construye /map)
   #################################################################
   slam_toolbox:
-    image: husarion/rosbot:humble-latest
+    image: husarion/rosbot-xl:humble-0.10.0-20240202
     network_mode: host
     privileged: true
     environment:
@@ -32,7 +32,7 @@ services:
   # 3) Tele-op por teclado  (publica /cmd_vel)
   #################################################################
   teleop:
-    image: husarion/rosbot:humble-latest
+    image: husarion/rosbot-xl:humble-0.10.0-20240202
     network_mode: host
     privileged: true
     tty: true

--- a/justfile
+++ b/justfile
@@ -65,9 +65,9 @@ flash-firmware: _install-yq _run-as-user
 start-rosbot: _run-as-user
     #!/bin/bash
     mkdir -m 775 -p maps
-    docker compose down
-    docker compose pull
-    docker compose up
+    docker compose -f compose.yaml down
+    docker compose -f compose.yaml pull
+    docker compose -f compose.yaml up
 
 # start the simulation (available options: gazebo, webots)
 start-simulation engine="gazebo": _run-as-user
@@ -143,7 +143,7 @@ _install-yq:
 
 teleop:
     @echo "Starting sensors + SLAM + teleop…"
-    docker compose up -d
+    docker compose -f compose.yaml -f docker-compose.override.yml up -d
     @echo ""
     @echo "╭───────────────────────────────────────────"
     @echo "│  TELEOP  (W/S = adelante/atrás)"


### PR DESCRIPTION
## Summary
- avoid teleop override when running normal rosbot
- use explicit compose file list for teleop recipe
- update teleop compose image references to rosbot-xl image

## Testing
- `pip install pre-commit` *(fails: Tunnel connection failed: 403 Forbidden)*
- `pre-commit run -a` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862c020bb78832383f47e7ed8aba3f1