### PR TITLE
Fix teleop start failure

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -7,8 +7,12 @@ services:
   #################################################################
   navigation:
     command: ["bash", "-c", "echo 'navigation disabled (teleop mapping)'; sleep infinity"]
+    healthcheck:
+      disable: true
   explore_lite:
     command: ["bash", "-c", "echo 'explore_lite disabled (teleop mapping)'; sleep infinity"]
+    healthcheck:
+      disable: true
 
   #################################################################
   # 2) Slam-Toolbox  (online_sync, construye /map)


### PR DESCRIPTION
## Summary
- disable health checks for `navigation` and `explore_lite` when teleop override is used

## Testing
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862c6d355b88323851535f2c5ca6e0c