### PR TITLE
Fix teleop startup

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -8,11 +8,11 @@ services:
   navigation:
     command: ["bash", "-c", "echo 'navigation disabled (teleop mapping)'; sleep infinity"]
     healthcheck:
-      disable: true
+      test: ["CMD", "true"]
   explore_lite:
     command: ["bash", "-c", "echo 'explore_lite disabled (teleop mapping)'; sleep infinity"]
     healthcheck:
-      disable: true
+      test: ["CMD", "true"]
 
   #################################################################
   # 2) Slam-Toolbox  (online_sync, construye /map)


### PR DESCRIPTION
## Summary
- avoid docker-compose dependency failure in `just teleop`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6862cafadbcc8323ad7983e1a5eaad0f