### PR TITLE
Rename foxglove service

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -30,7 +30,7 @@ services:
           slam_params_file:=/ros_ws/src/slam_toolbox/config/mapper_params_online_sync.yaml
           use_sim_time:=false"
     depends_on:
-      - rosbot
+      - rosbot               # ← IMPORTANTE: el nombre que SÍ existe
 
   #################################################################
   # 3) Tele-op por teclado  (publica /cmd_vel)
@@ -51,17 +51,17 @@ services:
     depends_on:
       - rosbot
 
-  #################################################################
-  # 4) Foxglove Bridge (WebSocket server)
-  #################################################################
-  foxglove_bridge:
+  # ────────────────────────────────
+  # Puente ROS 2 ⇆ Foxglove WebSocket
+  # ────────────────────────────────
+  foxglove-ws:
     image: ghcr.io/foxglove/foxglove-bridge:latest
     network_mode: host
     privileged: true
     environment:
       - ROS_DOMAIN_ID=0
     depends_on:
-      - rosbot
+      - rosbot               # ← IMPORTANTE: el nombre que SÍ existe
     command: >
       bash -c "
         source /opt/ros/humble/setup.bash &&


### PR DESCRIPTION
## Summary
- rename `foxglove_bridge` service to `foxglove-ws`
- update comments and add explicit rosbot dependency comment

## Testing
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862d45bbbd48323a4858b6332a70a9e