### PR TITLE
Update docker images for teleop and Foxglove

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -36,7 +36,7 @@ services:
   # 3) Tele-op por teclado  (publica /cmd_vel)
   #################################################################
   teleop:
-    image: husarion/rosbot:humble-latest
+    image: husarion/rosbot-xl:humble-0.10.0-20240202
     network_mode: host
     privileged: true
     stdin_open: true
@@ -53,7 +53,7 @@ services:
   # Puente ROS 2 ⇆ Foxglove WebSocket
   # ────────────────────────────────
   foxglove-ws:
-    image: husarion/rosbot:humble-latest
+    image: husarion/rosbot-xl:humble-0.10.0-20240202
     network_mode: host
     privileged: true
     environment:


### PR DESCRIPTION
## Summary
- update `teleop` and `foxglove-ws` services to use the same ROSbot XL image as the other services

## Testing
- `pip install pre-commit` *(fails: Could not connect to pypi.org)*


------
https://chatgpt.com/codex/tasks/task_e_68651405b3688323b78a8bd8c02b9a53