### PR TITLE
Fix port mapping for foxglove UI

### DIFF
--- a/compose.simulation.yaml
+++ b/compose.simulation.yaml
@@ -39,7 +39,6 @@ services:
     image: husarion/foxglove:1.84.0
     ports:
       - 8080:8080
-      - 8765:8765
     volumes:
       - ./config/layout.json:/foxglove/default-layout.json
     environment:


### PR DESCRIPTION
## Summary
- remove the `8765:8765` port mapping from the Foxglove UI service so only the Web UI is exposed via port 8080

## Testing
- `pre-commit` *(fails: could not install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68651f097b50832381bcc6b5585d1dcb