### PR TITLE
Update foxglove override image

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -54,6 +54,7 @@ services:
   # ────────────────────────────────
   # UI web: sólo 8080 -> host
   foxglove:
+    image: husarion/foxglove:latest
     network_mode: bridge
     ports:
       - "8080:8080"              #  <-- elimina 8765:8765 si estaba


### PR DESCRIPTION
## Summary
- set `husarion/foxglove:latest` in `docker-compose.override.yml` for the `foxglove` service

## Testing
- ❌ `docker compose -f compose.yaml -f docker-compose.override.yml config` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68652e3a36248323be0044f4f793cf1d