### PR TITLE
Add minimal override for foxglove studio

### DIFF
--- a/rosbotxl/docker-compose.override.yml
+++ b/rosbotxl/docker-compose.override.yml
@@ -1,0 +1,4 @@
+services:
+  foxglove:
+    image: husarion/foxglove:studio          # 1.94.0 con LaserScan
+


### PR DESCRIPTION
## Summary
- add `docker-compose.override.yml` in `rosbotxl` for Foxglove Studio

## Testing
- `pre-commit run --files rosbotxl/docker-compose.override.yml` *(fails: command not found)*
- `docker compose up -d foxglove` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865309107388323b4fa6bb697a8fdf9