### PR TITLE
Change foxglove image to studio

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -54,7 +54,7 @@ services:
   # ────────────────────────────────
   # UI web: sólo 8080 -> host
   foxglove:
-    image: husarion/foxglove:latest
+    image: husarion/foxglove:studio
     network_mode: bridge
     ports:
       - "8080:8080"              #  <-- elimina 8765:8765 si estaba


### PR DESCRIPTION
## Summary
- use `husarion/foxglove:studio` in the main Docker Compose override

## Testing
- `pre-commit run -a` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865455f94f0832399a14ffec1a116e8