### PR TITLE
Change Foxglove port to 8766

### DIFF
--- a/compose.simulation.yaml
+++ b/compose.simulation.yaml
@@ -43,7 +43,7 @@ services:
       - ./config/layout.json:/foxglove/default-layout.json
     environment:
       - DS_TYPE=foxglove-websocket
-      - DS_PORT=8765
+      - DS_PORT=8766
       - DS_HOST=foxglove-ds
       - UI_PORT=8080
       - DISABLE_CACHE=true
@@ -51,4 +51,4 @@ services:
 
   foxglove-ds:
     image: husarion/foxglove-bridge:humble-0.7.3-20240108
-    command: ros2 launch foxglove_bridge foxglove_bridge_launch.xml port:=8765 capabilities:=[clientPublish,connectionGraph,assets]
+    command: ros2 launch foxglove_bridge foxglove_bridge_launch.xml port:=8766 capabilities:=[clientPublish,connectionGraph,assets]

--- a/compose.yaml
+++ b/compose.yaml
@@ -48,7 +48,7 @@ services:
       - ./config/layout.json:/foxglove/default-layout.json
     environment:
       - DS_TYPE=foxglove-websocket
-      - DS_PORT=8765
+      - DS_PORT=8766
       - DS_HOST=foxglove-ds
       - UI_PORT=8080
       - DISABLE_CACHE=true
@@ -60,7 +60,7 @@ services:
     network_mode: host
     command: >
       ros2 launch foxglove_bridge foxglove_bridge_launch.xml
-        port:=8765
+        port:=8766
         capabilities:=[clientPublish,connectionGraph,assets]
 
   explore_lite:

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -46,7 +46,7 @@ services:
     image: husarion/foxglove-bridge:humble-0.7.3-20240108
     network_mode: bridge
     privileged: true
-    ports: [ "8765:8765" ]
+    ports: [ "8766:8766" ]
     environment: [ ROS_DOMAIN_ID=0 ]
     depends_on:
       rosbot:  { condition: service_started }


### PR DESCRIPTION
## Summary
- change Foxglove service port from 8765 to 8766

## Testing
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866628aea888323aec02de2c6b0eff7