### PR TITLE
Remove exposed port for foxglove bridge

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -46,7 +46,6 @@ services:
     image: husarion/foxglove-bridge:humble-0.7.3-20240108
     network_mode: bridge
     privileged: true
-    ports: [ "8765:8765" ]
     environment: [ ROS_DOMAIN_ID=0 ]
     depends_on:
       rosbot:  { condition: service_started }


### PR DESCRIPTION
## Summary
- keep Foxglove bridge internal by removing host port mapping

## Testing
- `pre-commit` *(fails: Could not install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686664fa19a8832391a677cdbdcc0574