### PR TITLE
Fix teleop foxglove bridge image

### DIFF
--- a/compose.simulation.yaml
+++ b/compose.simulation.yaml
@@ -50,7 +50,7 @@ services:
       - DISABLE_INTERACTION=false
 
   foxglove_bridge:
-    image: ghcr.io/foxglove/ros-foxglove-bridge:0.8.6
+    image: husarion/foxglove-bridge:humble-0.8.6-20240531
     command: >
       foxglove_bridge
         --address 0.0.0.0

--- a/compose.yaml
+++ b/compose.yaml
@@ -55,7 +55,7 @@ services:
       - DISABLE_INTERACTION=false
 
   foxglove_bridge:
-    image: ghcr.io/foxglove/ros-foxglove-bridge:0.8.6
+    image: husarion/foxglove-bridge:humble-0.8.6-20240531
     restart: unless-stopped
     network_mode: host
     command: >

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -43,7 +43,7 @@ services:
   # 5) Foxglove‑bridge con buffer / canales amplios
   ###############################################################
   foxglove_bridge:
-    image: ghcr.io/foxglove/ros-foxglove-bridge:0.8.6
+    image: husarion/foxglove-bridge:humble-0.8.6-20240531
     network_mode: bridge
     privileged: true
     environment: [ ROS_DOMAIN_ID=0 ]


### PR DESCRIPTION
## Summary
- use public Docker Hub image for `foxglove_bridge`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68666d22a22c83239095d530b66a23d6