### PR TITLE
Fix foxglove bridge image tag

### DIFF
--- a/compose.simulation.yaml
+++ b/compose.simulation.yaml
@@ -50,7 +50,7 @@ services:
       - DISABLE_INTERACTION=false
 
   foxglove_bridge:
-    image: husarion/foxglove-bridge:humble-0.8.6-20240531
+    image: ghcr.io/foxglove/ros-foxglove-bridge:0.8.6
     command: >
       foxglove_bridge
         --address 0.0.0.0

--- a/compose.yaml
+++ b/compose.yaml
@@ -55,7 +55,7 @@ services:
       - DISABLE_INTERACTION=false
 
   foxglove_bridge:
-    image: husarion/foxglove-bridge:humble-0.8.6-20240531
+    image: ghcr.io/foxglove/ros-foxglove-bridge:0.8.6
     restart: unless-stopped
     network_mode: host
     command: >

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -43,7 +43,7 @@ services:
   # 5) Foxglove‑bridge con buffer / canales amplios
   ###############################################################
   foxglove_bridge:
-    image: husarion/foxglove-bridge:humble-0.8.6-20240531
+    image: ghcr.io/foxglove/ros-foxglove-bridge:0.8.6
     network_mode: bridge
     privileged: true
     environment: [ ROS_DOMAIN_ID=0 ]


### PR DESCRIPTION
## Summary
- fix `foxglove_bridge` container image reference so it points to the public image

## Testing
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68666ec9e80c8323bb6c14d40a7d4e5a