### PR TITLE
Add static TF publisher

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -57,3 +57,17 @@ services:
   # 6) Foxglove Studio (UI) – sin cambios
   ###############################################################
   # foxglove  se queda tal y como está en tu compose.yaml
+
+  ###############################################################
+  # 7) Static transform laser -> camera
+  ###############################################################
+  static_tf:
+    image: husarion/rosbot-xl:humble-0.10.0-20240202
+    network_mode: host
+    restart: unless-stopped
+    environment: [ ROS_DOMAIN_ID=0 ]
+    command: >
+      ros2 run tf2_ros static_transform_publisher
+        0.10 0.00 0.15
+        0 0 0
+        laser oak_rgb_camera_optical_frame


### PR DESCRIPTION
## Summary
- add `static_tf` service to publish laser->camera transform on startup

## Testing
- `pre-commit` *(fails: pre-commit not installed)*
- `docker compose up -d --remove-orphans` *(fails: `docker` not installed)*
- `docker compose ps --status=running` *(fails: `docker` not installed)*
- `ros2 run tf2_tools view_frames --duration 2` *(fails: `ros2` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6866b927aabc83238a66bdde3d033a79