### PR TITLE
Fix compose indentation for new services

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -61,29 +61,29 @@ services:
 ###############################################################
 # 7) Static transform  (láser 20 cm delante de la cámara y 30 cm abajo)
 ###############################################################
-static_tf:
-  image: husarion/rosbot-xl:humble-0.10.0-20240202
-  network_mode: host
-  restart: unless-stopped
-  environment: [ ROS_DOMAIN_ID=0 ]          # mismo dominio DDS
-  command: >
-    ros2 run tf2_ros static_transform_publisher
-      -0.20 0.00 0.30                       # x y z  (–20 cm, 0, +30 cm)
-      -1.5708 0 1.5708                      # roll -90°, pitch 0, yaw +90° (rad)
-      laser oak_rgb_camera_optical_frame
+  static_tf:
+    image: husarion/rosbot-xl:humble-0.10.0-20240202
+    network_mode: host
+    restart: unless-stopped
+    environment: [ ROS_DOMAIN_ID=0 ]          # mismo dominio DDS
+    command: >
+      ros2 run tf2_ros static_transform_publisher
+        -0.20 0.00 0.30                       # x y z  (–20 cm, 0, +30 cm)
+        -1.5708 0 1.5708                      # roll -90°, pitch 0, yaw +90° (rad)
+        laser oak_rgb_camera_optical_frame
 
 ###############################################################
 # 8) Overlay  (imagen OAK + puntos RPLIDAR)
 ###############################################################
-overlay:
-  image: husarion/rosbot-xl:humble-0.10.0-20240202
-  network_mode: host
-  restart: unless-stopped
-  environment: [ ROS_DOMAIN_ID=0 ]
-  volumes:
-    - ./scripts/lidar_overlay.py:/overlay.py:ro    # monta el script
-  command: >
-    bash -c "pip3 install -q --no-cache-dir scipy &&
-             python3 /overlay.py"
-  depends_on:
-    static_tf: { condition: service_started }
+  overlay:
+    image: husarion/rosbot-xl:humble-0.10.0-20240202
+    network_mode: host
+    restart: unless-stopped
+    environment: [ ROS_DOMAIN_ID=0 ]
+    volumes:
+      - ./scripts/lidar_overlay.py:/overlay.py:ro    # monta el script
+    command: >
+      bash -c "pip3 install -q --no-cache-dir scipy &&
+               python3 /overlay.py"
+    depends_on:
+      static_tf: { condition: service_started }


### PR DESCRIPTION
## Summary
- fix indentation for `static_tf` and `overlay` services in `docker-compose.override.yml`

## Testing
- `pre-commit run --files docker-compose.override.yml` *(fails: pre-commit not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867fd187bd08323a6c39ff39b4e731e