### PR TITLE
Fix overlay script path and update compose

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -59,7 +59,7 @@ services:
   # foxglove  se queda tal y como está en tu compose.yaml
 
 ###############################################################
-# 7) Static transform  (láser 20 cm delante de la cámara y 30 cm abajo)
+# 7) Static transform  (láser 20 cm detrás, 30 cm arriba)
 ###############################################################
   static_tf:
     image: husarion/rosbot-xl:humble-0.10.0-20240202
@@ -67,8 +67,8 @@ services:
     restart: unless-stopped
     environment: [ ROS_DOMAIN_ID=0 ]
     command: [ "ros2", "run", "tf2_ros", "static_transform_publisher",
-               "-0.20", "0.00", "0.30",
-               "-1.5708", "0", "1.5708",
+               "-0.20", "0.00", "0.30",        # x  y  z
+               "-1.5708", "0", "1.5708",       # roll  pitch  yaw
                "laser", "oak_rgb_camera_optical_frame" ]
 
 ###############################################################
@@ -81,8 +81,7 @@ services:
     environment: [ ROS_DOMAIN_ID=0 ]
     volumes:
       - ./scripts/lidar_overlay.py:/overlay.py:ro
-    command: [ "bash", "-c",
-               "python3 -m pip install -q --no-cache-dir scipy && python3 /overlay.py" ]
+    command: [ "python3", "/overlay.py" ]     # ← NO usa pip / scipy
     depends_on:
       static_tf:
         condition: service_started

--- a/scripts/lidar_overlay.py
+++ b/scripts/lidar_overlay.py
@@ -6,7 +6,14 @@ from sensor_msgs_py import point_cloud2 as pc2
 from laser_geometry import LaserProjection
 from tf2_ros import Buffer, TransformListener, Time
 from cv_bridge import CvBridge
-from scipy.spatial.transform import Rotation as R
+
+def quat_to_rot(q):
+    x, y, z, w = q
+    return np.array([
+        [1-2*(y*y+z*z), 2*(x*y-z*w),   2*(x*z+y*w)],
+        [2*(x*y+z*w),   1-2*(x*x+z*z), 2*(y*z-x*w)],
+        [2*(x*z-y*w),   2*(y*z+x*w),   1-2*(x*x+y*y)]
+    ])
 
 class Overlay(Node):
     def __init__(self):
@@ -31,13 +38,13 @@ class Overlay(Node):
         t = tr.transform.translation
         trans = np.array([t.x, t.y, t.z])
         q = tr.transform.rotation
-        rot = R.from_quat([q.x, q.y, q.z, q.w]).as_matrix()
+        rot = quat_to_rot((q.x, q.y, q.z, q.w))
 
         cloud = self.lp.projectLaser(self.scan)
         pts = pc2.read_points(cloud, field_names=('x','y','z'), skip_nans=True)
 
         cv_img = self.br.imgmsg_to_cv2(img)
-        h, w   = cv_img.shape[:2]
+        h, w = cv_img.shape[:2]
         fx, fy, cx, cy = (self.cam_info.k[0], self.cam_info.k[4],
                           self.cam_info.k[2], self.cam_info.k[5])
 
@@ -49,7 +56,7 @@ class Overlay(Node):
                 cv2.circle(cv_img, (u, v), 2, (0, 255, 0), -1)
 
         out = self.br.cv2_to_imgmsg(cv_img, encoding='bgr8')
-        out.header = img.header          # copia frame_id / timestamp
+        out.header = img.header            # frame_id + timestamp
         self.pub.publish(out)
 
 def main():


### PR DESCRIPTION
## Summary
- update `docker-compose.override.yml` overlay service to avoid pip usage
- implement `quat_to_rot` in `scripts/lidar_overlay.py`
- revert stray `rosbotxl` override file and remove duplicate overlay script

## Testing
- `pre-commit run -a` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868056f4a04832395c515a2473fc4c2