### PR TITLE
Fix overlay service to install OpenCV

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -81,7 +81,9 @@ services:
     environment: [ ROS_DOMAIN_ID=0 ]
     volumes:
       - ./scripts/lidar_overlay.py:/overlay.py:ro
-    command: [ "python3", "/overlay.py" ]     # ← NO usa pip / scipy
+    command: [ "bash", "-c",
+               "apt-get update -qq && apt-get install -y python3-opencv && \
+                python3 /overlay.py" ]
     depends_on:
       static_tf:
         condition: service_started


### PR DESCRIPTION
## Summary
- install `python3-opencv` on container start for overlay service

## Testing
- `pre-commit` *(fails: command not found and cannot install due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_686809546a24832380d6d09ad728b727