### PR TITLE
Add auto_loop Docker service

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -88,3 +88,23 @@ services:
     depends_on:
       static_tf:
         condition: service_started
+
+  ###############################################################
+  # 9) Rectangular patrol  (auto_loop)
+  ###############################################################
+  auto_loop:
+    image: husarion/navigation2:humble-1.1.12-20240123
+    network_mode: host
+    restart: unless-stopped
+    depends_on:
+      navigation: { condition: service_started }
+    volumes:
+      - ./rosbotxl/rosbotxl_auto:/opt/ws/src/rosbotxl_auto:ro
+      - ./maps:/maps:ro
+    command: >
+      bash -c "
+        source /opt/ros/humble/setup.bash &&
+        cd /opt/ws &&
+        colcon build --packages-select rosbotxl_auto &&
+        source install/setup.bash &&
+        ros2 launch rosbotxl_auto auto_loop.launch.py"

--- a/docs/auto_loop_es.md
+++ b/docs/auto_loop_es.md
@@ -177,14 +177,13 @@ source install/setup.bash
 
 2 · Añadir la “just recipe” sin romper las existentes
 
-Abre justfile y al final añade:
+Abre `justfile` y al final añade:
 
 ```makefile
 # ejecuta el bucle rectangular autónomo
 auto-loop: _run-as-user
     #!/bin/bash
-    source ~/rosbotxl/install/setup.bash
-    ros2 launch rosbotxl_auto auto_loop.launch.py
+    docker compose -f compose.yaml -f docker-compose.override.yml up -d auto_loop
 ```
 
 3 · No toques explore‑lite ni tus YAML actuales

--- a/justfile
+++ b/justfile
@@ -155,5 +155,4 @@ teleop:
 # ejecuta el bucle rectangular autónomo
 auto-loop: _run-as-user
     #!/bin/bash
-    source ~/rosbotxl/install/setup.bash
-    ros2 launch rosbotxl_auto auto_loop.launch.py
+    docker compose -f compose.yaml -f docker-compose.override.yml up -d auto_loop


### PR DESCRIPTION
## Summary
- run auto_loop inside its own container
- update justfile recipe
- document new usage

## Testing
- `colcon build --packages-select rosbotxl_auto` *(fails: command not found)*
- `pip install colcon-common-extensions` *(fails: cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6877d884bed0832392473d398a99d465