### PR TITLE
Ensure microros starts with rosbot container

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -4,6 +4,9 @@ services:
     image: husarion/rosbot-xl:humble-0.10.0-20240202
     restart: unless-stopped
     command: ros2 launch rosbot_xl_bringup bringup.launch.py mecanum:=${MECANUM:-True}
+    depends_on:
+      microros:
+        condition: service_started
 
   microros:
     image: husarion/micro-ros-agent:humble-3.1.3-20240126


### PR DESCRIPTION
## Summary
- start micro-ROS agent whenever the rosbot container launches

## Testing
- `pre-commit run -a` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877ddf374888323b246758bcdb7dc70