### PR TITLE
Fix auto_loop container restart

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -103,6 +103,13 @@ services:
       - ./maps:/maps:ro
     command: >
       bash -c "
+        # instalar colcon solo la primera vez (1-2 s)
+        if ! command -v colcon &> /dev/null; then
+          apt-get update -qq &&
+          apt-get install -y --no-install-recommends \
+            python3-colcon-common-extensions && \
+          rm -rf /var/lib/apt/lists/*
+        fi &&
         source /opt/ros/humble/setup.bash &&
         cd /opt/ws &&
         colcon build --packages-select rosbotxl_auto &&


### PR DESCRIPTION
## Summary
- install `python3-colcon-common-extensions` when `colcon` is absent

## Testing
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877e1287010832386591679c649e65d