### PR TITLE
Apply navigation SLAM update and new just recipe

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -33,6 +33,12 @@ services:
   navigation:
     volumes:
       - ./maps:/home/husarion/rosbotxl/maps
+    command: >
+      ros2 launch /husarion_utils/bringup_launch.py
+        slam:=false
+        params_file:=/params.yaml
+        map:=/maps/mapa_nave.yaml
+        use_sim_time:=False
 
   ###############################################################
   # 4) explore_lite dormido (evita exploración autónoma)
@@ -103,11 +109,9 @@ services:
       - ./maps:/maps:ro
     command: >
       bash -c "
-        # instalar colcon solo la primera vez (1-2 s)
         if ! command -v colcon &> /dev/null; then
           apt-get update -qq &&
-          apt-get install -y --no-install-recommends \
-            python3-colcon-common-extensions && \
+          apt-get install -y python3-colcon-common-extensions &&
           rm -rf /var/lib/apt/lists/*
         fi &&
         source /opt/ros/humble/setup.bash &&

--- a/justfile
+++ b/justfile
@@ -156,3 +156,9 @@ teleop:
 auto-loop: _run-as-user
     #!/bin/bash
     docker compose -f compose.yaml -f docker-compose.override.yml up -d auto_loop
+
+# arranca drivers + navegación con mapa fijo + patrulla rectangular
+run-patrol: _run-as-user
+    #!/bin/bash
+    docker compose -f compose.yaml -f docker-compose.override.yml \
+      up -d rosbot rplidar microros navigation auto_loop


### PR DESCRIPTION
## Summary
- adjust nav2 command to use a fixed map without SLAM
- simplify `auto_loop` build/install steps
- add `run-patrol` recipe for quick autonomous patrol startup

## Testing
- `pre-commit run --files docker-compose.override.yml justfile` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877e63d44c8832381b787c7a619c266