### PR TITLE
Fix teleop config

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -33,12 +33,6 @@ services:
   navigation:
     volumes:
       - ./maps:/home/husarion/rosbotxl/maps
-    command: >
-      ros2 launch /husarion_utils/bringup_launch.py
-        slam:=false
-        params_file:=/params.yaml
-        map:=/maps/mapa_nave.yaml
-        use_sim_time:=False
 
   ###############################################################
   # 4) explore_lite dormido (evita exploración autónoma)

--- a/docker-compose.patrol.yml
+++ b/docker-compose.patrol.yml
@@ -1,0 +1,10 @@
+version: "3.8"
+
+services:
+  navigation:
+    command: >
+      ros2 launch /husarion_utils/bringup_launch.py
+        slam:=false
+        params_file:=/params.yaml
+        map:=/maps/mapa_nave.yaml
+        use_sim_time:=False

--- a/justfile
+++ b/justfile
@@ -160,5 +160,5 @@ auto-loop: _run-as-user
 # arranca drivers + navegación con mapa fijo + patrulla rectangular
 run-patrol: _run-as-user
     #!/bin/bash
-    docker compose -f compose.yaml -f docker-compose.override.yml \
+    docker compose -f compose.yaml -f docker-compose.override.yml -f docker-compose.patrol.yml \
       up -d rosbot rplidar microros navigation auto_loop


### PR DESCRIPTION
## Summary
- revert navigation override to keep SLAM enabled for `just teleop`
- add separate compose file for patrol mode
- update `run-patrol` recipe to use new compose file

## Testing
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877f91d8e708323a5089bc82c36a31f