### PR TITLE
Fix teleop navigation mount path

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -32,6 +32,11 @@ services:
   ###############################################################
   navigation:
     volumes:
+      # Mount original navigation parameters
+      - ./config/nav2_${CONTROLLER:-rpp}_params.yaml:/params.yaml
+      # Map files available under the default path used by the launch script
+      - ./maps:/maps
+      # Additional mount for manual access inside the container
       - ./maps:/home/husarion/rosbotxl/maps
     command: >
       ros2 launch /husarion_utils/bringup_launch.py


### PR DESCRIPTION
## Summary
- fix navigation volume mount paths so map is available during `just teleop`

## Testing
- `pip install pre-commit` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_6878da6bbe14832389e4b69cad5fcb33