### PR TITLE
Remove navigation volumes from teleop override

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -30,20 +30,8 @@ services:
   ###############################################################
   # 3) Navigation 2 (activo: genera /map)
   ###############################################################
-  navigation:
-    volumes:
-      # Mount original navigation parameters
-      - ./config/nav2_${CONTROLLER:-rpp}_params.yaml:/params.yaml
-      # Map files available under the default path used by the launch script
-      - ./maps:/maps
-      # Additional mount for manual access inside the container
-      - ./maps:/home/husarion/rosbotxl/maps
-    command: >
-      ros2 launch /husarion_utils/bringup_launch.py
-        slam:=false
-        params_file:=/params.yaml
-        map:=/maps/mapa_nave.yaml
-        use_sim_time:=False
+  # -- no lo tocamos: se mantiene igual que en compose.yaml
+  #   (si quieres usar otros parámetros de SLAM, cámbialos ahí)
 
   ###############################################################
   # 4) explore_lite dormido (evita exploración autónoma)


### PR DESCRIPTION
## Summary
- revert navigation container customization in `docker-compose.override.yml`

## Testing
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878dc30a53083238f76364de8eb0596