### PR TITLE
Fix nav launch boolean

### DIFF
--- a/docs/auto_loop_es.md
+++ b/docs/auto_loop_es.md
@@ -97,7 +97,7 @@ def generate_launch_description():
     nav2 = ExecuteProcess(
         cmd=[
             'ros2','launch','nav2_bringup','bringup_launch.py',
-            f'slam:=false',
+            f'slam:=False',
             f'map:={MAP}',
             'autostart:=true'
         ],

--- a/rosbotxl/rosbotxl_auto/rosbotxl_auto/auto_loop.launch.py
+++ b/rosbotxl/rosbotxl_auto/rosbotxl_auto/auto_loop.launch.py
@@ -27,7 +27,7 @@ def generate_launch_description():
             "launch",
             "nav2_bringup",
             "bringup_launch.py",
-            "slam:=false",
+            "slam:=False",
             f"map:={MAP}",
             "autostart:=true",
         ],


### PR DESCRIPTION
## Summary
- ensure Nav2 launch uses correct Python boolean value

## Testing
- `black rosbotxl/rosbotxl_auto/rosbotxl_auto/auto_loop.launch.py`
- *(fails: pre-commit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6878de50d9f0832393c728afe8cbe0fb