### PR TITLE
fix overlay command for opencv

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -81,9 +81,14 @@ services:
     environment: [ ROS_DOMAIN_ID=0 ]
     volumes:
       - ./scripts/lidar_overlay.py:/overlay.py:ro
-    command: [ "bash", "-c",
-               "apt-get update -qq && apt-get install -y python3-opencv && \
-                python3 /overlay.py" ]
+    command: >
+      bash -c "
+        curl -fsSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key \
+          | gpg --dearmor -o /usr/share/keyrings/ros-archive-keyring.gpg && \
+        sed -i 's#signed-by=/usr/share/keyrings/.*#signed-by=/usr/share/keyrings/ros-archive-keyring.gpg#' \
+          /etc/apt/sources.list.d/ros2.list && \
+        apt-get update -qq && apt-get install -y --no-install-recommends python3-opencv && \
+        python3 /overlay.py"
     depends_on:
       static_tf:
         condition: service_started


### PR DESCRIPTION
## Summary
- update overlay service command to install OpenCV and run python script

## Testing
- `python3 - <<'EOF'
import yaml, sys
try:
    yaml.safe_load(open('docker-compose.override.yml'))
    print('YAML OK')
except Exception as e:
    print('YAML Error:', e)
EOF` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68680ca5aed083239659e41a54576b28