### PR TITLE
Fix teleop script

### DIFF
--- a/justfile
+++ b/justfile
@@ -143,6 +143,7 @@ _install-yq:
 
 teleop:
     @echo "Starting sensors + SLAM + teleop…"
+    mkdir -m 775 -p maps
     docker compose -f compose.yaml -f docker-compose.override.yml up -d
     @echo ""
     @echo "╭───────────────────────────────────────────"


### PR DESCRIPTION
## Summary
- ensure maps directory exists before starting teleop

## Testing
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68792449fdb08323965274e15f60a561