### PR TITLE
Update compose override with OAK configuration

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -8,7 +8,11 @@ services:
     command: >
       ros2 launch rosbot_xl_bringup bringup.launch.py
         mecanum:=${MECANUM:-True}
-        enable_oak:=false
+        enable_oak:=true
+        rgb_camera_width:=1920
+        rgb_camera_height:=1080
+        rgb_camera_fps:=30
+        rgb_camera_compression_quality:=95
 
   ###############################################################
   # 2) teleop_twist_keyboard (mover el robot)


### PR DESCRIPTION
## Summary
- enable OAK camera and configure RGB settings in `docker-compose.override.yml`

## Testing
- `pip install pre-commit` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_687a731656f083239d6b2c16bb769b87