### PR TITLE
Update rplidar configuration

### DIFF
--- a/.env
+++ b/.env
@@ -6,7 +6,7 @@
 # - 1000000 - for RPlidar S2 and S3
 # - 256000 - for RPlidar S1, A2M12 and A3 (violet circle around the sensor)
 # - 115200 - for RPlidar A2M8 (red circle around the sensor)
-LIDAR_BAUDRATE=256000
+LIDAR_BAUDRATE=1000000
 
 # Select wheel type:
 # - True - mecanum wheels

--- a/README.md
+++ b/README.md
@@ -79,11 +79,14 @@ just sync rosbotxl
 
 To ensure proper user configuration, review the content of the `.env` file and select the appropriate configuration (the default options should be suitable).
 
-- **`LIDAR_BAUDRATE`** - depend on mounted LiDAR,
 - **`MECANUM`** - wheel type,
 - **`SLAM`** - choose between mapping and localization modes,
 - **`SAVE_MAP_PERIOD`** - period of time for autosave map (set `0` to disable),
 - **`CONTROLLER`** - choose the navigation controller type,
+
+The RPLIDAR sensor is configured in `compose.yaml` to use `/dev/ttyUSB1`
+with a baud rate of `1000000`. Adjust these settings in the Compose file
+if your hardware requires a different configuration.
 
 ### 🤖 Step 4: Running Navigation & Mapping
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -15,13 +15,17 @@ services:
   rplidar:
     image: husarion/rplidar:humble-1.0.1-20240104
     restart: unless-stopped
+
+    # Usa el puerto que acabamos de comprobar
     devices:
-      - /dev/ttyUSB0:/dev/ttyUSB0
+      - /dev/ttyUSB1:/dev/ttyUSB1
+
     command: >
       ros2 launch /husarion_utils/rplidar.launch.py
-        serial_baudrate:=${LIDAR_BAUDRATE:-1000000}
-        serial_port:=/dev/ttyUSB0
-    environment: [ ROS_DOMAIN_ID=0 ]
+        serial_port:=/dev/ttyUSB1
+        serial_baudrate:=1000000
+
+    environment: [ROS_DOMAIN_ID=0]
     healthcheck:
       test: ["CMD-SHELL",
              "bash -c 'source /opt/ros/humble/setup.bash && ros2 topic list | grep -q ^/scan$'"]


### PR DESCRIPTION
## Summary
- update `compose.yaml` rplidar to use `/dev/ttyUSB1` and 1000000 baud
- adjust `.env` default baudrate
- update docs to explain rplidar port settings

## Testing
- `pre-commit run --files compose.yaml .env README.md` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fb923cdbc8323b279365d2a3674cb