### PR TITLE
Configure depthai service

### DIFF
--- a/config/oak_1080p.yaml
+++ b/config/oak_1080p.yaml
@@ -1,0 +1,6 @@
+/oak:
+  ros__parameters:
+    rgb:
+      i_resolution: "1080P"
+      i_fps:       30.0
+      i_output_isp: false

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -88,3 +88,18 @@ services:
     depends_on:
       static_tf:
         condition: service_started
+
+  ###############################################################
+  # 9) DepthAI camera service
+  ###############################################################
+  depthai:
+    image: husarion/rosbot-xl:humble-0.10.0-20240202
+    network_mode: host
+    privileged: true
+    restart: unless-stopped
+    environment: [ ROS_DOMAIN_ID=0 ]
+    volumes:
+      - ./config/oak_1080p.yaml:/config/oak_1080p.yaml:ro
+    command: >
+      ros2 launch depthai_ros_driver camera.launch.py
+        params_file:=/config/oak_1080p.yaml


### PR DESCRIPTION
## Summary
- add configuration for Oak camera at 1080p
- enable depthai service with the new configuration in docker-compose override

## Testing
- `pre-commit` *(fails: command not found)*
- `docker compose -f compose.yaml -f docker-compose.override.yml config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68821a39018c8323880f99fb752359a3