### PR TITLE
Add maps volume to rosbot service

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -9,6 +9,8 @@ services:
       ros2 launch rosbot_xl_bringup bringup.launch.py
         mecanum:=${MECANUM:-True}
         enable_oak:=false
+    volumes:
+      - ./maps:/maps
 
   ###############################################################
   # 2) teleop_twist_keyboard (mover el robot)


### PR DESCRIPTION
## Summary
- add `./maps:/maps` volume to rosbot in `docker-compose.override.yml`

## Testing
- `pre-commit run --files docker-compose.override.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68825a7743a083239780a5e0525071e9