### PR TITLE
Update ROSbot configuration for OAK-D

### DIFF
--- a/config/oak_1080p.yaml
+++ b/config/oak_1080p.yaml
@@ -5,4 +5,4 @@
       i_fps:       30.0
       i_publish_topic: true
       i_enable_preview: false
-      i_output_isp: false
+      i_output_isp: true          # ← publicar frame ISP completo

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -2,15 +2,21 @@ version: "3.8"
 
 services:
   ###############################################################
-  # 1) rosbot: drivers SIN cámara OAK
+  # 1) rosbot: drivers con cámara OAK
   ###############################################################
   rosbot:
+    image: husarion/rosbot-xl:humble-0.10.0-20240202
+    network_mode: host
+    privileged: true
+    restart: unless-stopped
+    environment: [ ROS_DOMAIN_ID=0 ]
+    volumes:
+      - ./maps:/maps
+      - ./config/oak_1080p.yaml:/config/oak_1080p.yaml:ro
     command: >
       ros2 launch rosbot_xl_bringup bringup.launch.py
         mecanum:=${MECANUM:-True}
-        enable_oak:=false
-    volumes:
-      - ./maps:/maps
+        depthai_params_file:=/config/oak_1080p.yaml
 
   ###############################################################
   # 2) teleop_twist_keyboard (mover el robot)


### PR DESCRIPTION
## Summary
- enable full-frame ISP output from the camera
- update rosbot service in `docker-compose.override.yml` to use the OAK-D configuration
- drop the unused `depthai` service override

## Testing
- `pip install pre-commit` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_6884f7ffeeec832380e964c16e3ad0cb