### PR TITLE
Disable camera preview

### DIFF
--- a/config/oak_1080p.yaml
+++ b/config/oak_1080p.yaml
@@ -1,8 +1,8 @@
 /oak:
   ros__parameters:
     rgb:
-      i_resolution: "1080P"
-      i_fps:       30.0
-      i_publish_topic: true
-      i_enable_preview: false
-      i_output_isp: true          # ← publicar frame ISP completo
+      i_resolution:      "1080P"
+      i_fps:             30.0
+      i_publish_topic:   false     # ← NO publicar el preview
+      i_enable_preview:  false
+      i_output_isp:      true      # ← Publicar ISP completo


### PR DESCRIPTION
## Summary
- change oak_1080p configuration to disable preview topic and update comments

## Testing
- `docker compose -f compose.yaml -f docker-compose.override.yml down` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884ffe0ffb083239437fe5ff4ca9660