### PR TITLE
Update path_tools command and just tasks

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -68,7 +68,8 @@ services:
     volumes:
       - ./routes:/routes
       - ./scripts:/scripts:ro
-    command: bash -c "sleep infinity"
+    # load the ROS environment before idling
+    command: bash -c "source /opt/ros/humble/setup.bash && sleep infinity"
     depends_on:
       navigation: { condition: service_started }
 

--- a/justfile
+++ b/justfile
@@ -158,12 +158,14 @@ teleop:
 record-path name:
     @echo "Grabando recorrido {{name}} –\u00a0pulsa Ctrl-C para terminar"
     docker exec -it $(docker compose ps -q path_tools) \
-        ros2 run path_tools path_recorder.py \
-        --output /routes/{{name}}.yaml
+        bash -c "source /opt/ros/humble/setup.bash && \
+                 python3 /scripts/path_recorder.py \
+                 --output /routes/{{name}}.yaml"
 
 # Reproducir un recorrido con Nav2 (esquiva de obstáculos)
 play-path name:
     @echo "Ejecutando recorrido {{name}}"
     docker exec -it $(docker compose ps -q path_tools) \
-        ros2 run path_tools path_player.py \
-        --file /routes/{{name}}.yaml
+        bash -c "source /opt/ros/humble/setup.bash && \
+                 python3 /scripts/path_player.py \
+                 --file /routes/{{name}}.yaml"


### PR DESCRIPTION
## Summary
- load ROS environment in `path_tools` service
- update `record-path` and `play-path` recipes to run Python scripts directly

## Testing
- `pip install pre-commit` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_6887896835d48323b5367e72fb589b2b