### PR TITLE
Restore teleop/start tasks

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -61,14 +61,17 @@ services:
         use_sim_time:=False
 
   path_tools:
-    build:
-      context: .
-      dockerfile: Dockerfile.path_tools
+    image: husarion/rosbot-xl:humble-0.10.0-20240202
     network_mode: host
+    restart: unless-stopped
+    environment: [ ROS_DOMAIN_ID=0 ]
     volumes:
       - ./routes:/routes
       - ./scripts:/scripts:ro
-    command: /ros_entrypoint.sh bash -c "sleep infinity"
+    # load the ROS environment before idling
+    command: bash -c "source /opt/ros/humble/setup.bash && sleep infinity"
+    depends_on:
+      navigation: { condition: service_started }
 
   foxglove:
     image: husarion/foxglove:1.84.0

--- a/justfile
+++ b/justfile
@@ -65,7 +65,9 @@ flash-firmware: _install-yq _run-as-user
 start-rosbot: _run-as-user
     #!/bin/bash
     mkdir -m 775 -p maps
-    docker compose -f compose.yaml up --build
+    docker compose -f compose.yaml down
+    docker compose -f compose.yaml pull
+    docker compose -f compose.yaml up
 
 # start the simulation (available options: gazebo, webots)
 start-simulation engine="gazebo": _run-as-user


### PR DESCRIPTION
## Summary
- revert `start-rosbot` to use compose down/pull/up instead of build
- revert `path_tools` service to previous image-based setup

## Testing
- `pre-commit` *(fails: Could not install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6887b659d2748323ab2a7b3651de4cde