### PR TITLE
Update navigation configuration and start1 recipe

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -43,22 +43,32 @@ services:
       retries: 10
 
   navigation:
-    image: husarion/navigation2:humble-1.1.12-20240123
-    restart: unless-stopped
-    depends_on:
-      rplidar:
-        condition: service_healthy
-      rosbot:
-        condition: service_healthy
+    image: husarion/rosbot-xl:humble-0.10.0-20240202
+    network_mode: host
+
+    # 1) monta tu carpeta ./maps (la que vimos con almacen1.yaml)
+    #    dentro del contenedor en /maps **solo-lectura**.
+    #    El sufijo ":ro" significa “read-only”: el contenedor
+    #    no podrá modificar tu mapa en disco.
     volumes:
-      - ./config/nav2_${CONTROLLER:-rpp}_params.yaml:/params.yaml
-      - ./maps:/maps
+      - ./maps:/maps:ro
+
+    # 2) lanza bringup en modo navegación *sin* SLAM y
+    #    cargando el mapa que ya tienes grabado.
     command: >
-      ros2 launch /husarion_utils/bringup_launch.py
-        slam:=${SLAM:-True}
+      ros2 launch rosbot_xl_bringup navigation.launch.py
+        slam:=False
+        map:=/maps/almacen1.yaml           # ← nombre EXACTO del mapa
         params_file:=/params.yaml
-        map:=/maps/map.yaml
         use_sim_time:=False
+
+    # 3) healthcheck (muchas imágenes de Husarion ya lo traen,
+    #    mantén lo que tengas; si no existe, deja esto)
+    healthcheck:
+      test: ["CMD", "ros2", "topic", "info", "/amcl_pose"]
+      interval: 10s
+      timeout: 5s
+      retries: 6
 
   path_tools:
     image: husarion/rosbot-xl:humble-0.10.0-20240202

--- a/justfile
+++ b/justfile
@@ -170,9 +170,17 @@ play-path name:
 
 # Iniciar el robot y reproducir el recorrido "circuito1" una vez Nav2 esté listo
 start1:
-    just start-rosbot &
-    WAIT=0; \
-    until docker compose ps navigation | grep -q "(healthy)"; do \
-        sleep 2; WAIT=$$((WAIT+2)); [ $$WAIT -gt 60 ] && echo "\u26d4 nav2 no sano" && exit 1; \
-    done
-    just play-path circuito1
+    # arranca todos los contenedores SIN reconstruir imágenes
+    @docker compose up -d
+
+    # espera hasta 60\s a que navigation reporte healthy
+    @echo "⌛  Esperando a Navigation…"
+    @bash -c 'for n in $$(seq 1 30); do \
+        docker compose ps navigation | grep -q healthy && exit 0; \
+        sleep 2; \
+      done; \
+      echo "⛔  Navigation no healthy"; exit 1'
+
+    # ejecuta la ruta circuito1.yaml desde path_tools
+    @echo "▶️  Ejecutando circuito1.yaml"
+    @just play-path circuito1


### PR DESCRIPTION
## Summary
- update `navigation` service for running from saved map
- update `start1` just recipe to run containers and wait for healthcheck

## Testing
- `pre-commit run -a` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887bbbb3d348323ae09d86070d04af8