### PR TITLE
OAK-D: enable depth and pointcloud pipeline

### DIFF
--- a/Dockerfile.path_tools
+++ b/Dockerfile.path_tools
@@ -1,0 +1,13 @@
+FROM husarion/navigation2:humble-1.1.12-20240123
+
+# Base ROS 2 + depth_image_proc (para point_cloud_xyz)
+RUN apt-get update -qq && apt-get install -y curl gnupg lsb-release && \
+    curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc \
+      | gpg --dearmor -o /usr/share/keyrings/ros2-latest-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) \
+      signed-by=/usr/share/keyrings/ros2-latest-archive-keyring.gpg] \
+      http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" \
+      > /etc/apt/sources.list.d/ros2-latest.list && \
+    apt-get update -qq && \
+    apt-get install -y ros-humble-depth-image-proc && \
+    rm -rf /var/lib/apt/lists/*

--- a/compose.yaml
+++ b/compose.yaml
@@ -61,14 +61,15 @@ services:
         use_sim_time:=False
 
   path_tools:
-    image: husarion/navigation2:humble-1.1.12-20240123
+    build:
+      context: .
+      dockerfile: Dockerfile.path_tools
     network_mode: host
     restart: unless-stopped
     environment: [ ROS_DOMAIN_ID=0 ]
     volumes:
       - ./routes:/routes
       - ./scripts:/scripts:ro
-    # load the ROS environment before idling
     command: bash -c "source /opt/ros/humble/setup.bash && sleep infinity"
     depends_on:
       navigation: { condition: service_started }

--- a/config/oak_1080p.yaml
+++ b/config/oak_1080p.yaml
@@ -1,8 +1,12 @@
-/oak:
+depthai_ros2:
   ros__parameters:
+    pipeline_type: RGBStereo
     rgb:
-      i_resolution: "1080P"
-      i_fps: 30.0
-      i_publish_topic: false      # NO publicar preview
-      i_enable_preview: false
-      i_output_isp: true          # publicar ISP
+      enable: true
+      resolution: 1080P
+      fps: 30
+    stereo_i:
+      enableDepth: true
+      subpixel: true
+      leftRightCheck: true
+      extended: true

--- a/justfile
+++ b/justfile
@@ -192,3 +192,19 @@ start-route ruta="mi_ruta":
 # ────────────────────────────────────────────────────────────────
 ruta1:
     just start-route mi_ruta
+
+# Genera PointCloud de la OAK (publica /oak/points) dentro de path_tools
+oak-points:
+    CID=$(docker compose ps -q path_tools)
+    docker exec -it $$CID bash -lc \
+      "source /opt/ros/humble/setup.bash && \
+       ros2 run depth_image_proc point_cloud_xyz \
+         --ros-args \
+         -r depth:=/oak/stereo/depth \
+         -r camera_info:=/oak/stereo/camera_info \
+         -r points:=/oak/points"
+
+# Detiene el conversor si quedó corriendo en otra terminal
+oak-points-stop:
+    CID=$(docker compose ps -q path_tools)
+    docker exec -it $$CID bash -lc "pkill -f depth_image_proc || true"


### PR DESCRIPTION
## Summary
- enable depth in OAK-D configuration
- build path_tools image with depth_image_proc and add just recipes to create/stop pointcloud

## Testing
- `just pre-commit` *(fails: command not found)*
- `apt-get update && apt-get install -y just` *(fails: repository not signed)*
- `pip install pre-commit` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68b6d83244e4832386118d306d79d7df