### PR TITLE
feat: continuous path playback and nav2 tuning

### DIFF
--- a/config/nav2_rpp_params.yaml
+++ b/config/nav2_rpp_params.yaml
@@ -78,6 +78,9 @@ bt_navigator:
     robot_base_frame: base_link
     odom_topic: odometry/filtered
 
+    # Deja el que trae tu imagen si ya replanifica; si no, apunta a un BT con replan.
+    # default_nav_through_poses_bt_xml: "/opt/ros/humble/share/nav2_bt_navigator/behavior_trees/navigate_through_poses_w_replanning_and_recovery.xml"
+
     bt_loop_duration: 10
     default_server_timeout: 20
     wait_for_service_timeout: 1000
@@ -128,65 +131,31 @@ controller_server:
     min_y_velocity_threshold: 0.01    # Measured
     min_theta_velocity_threshold: 0.1 # Measured
 
-    progress_checker_plugin: progress_checker
+    progress_checker_plugins: ["progress_checker"]
+    goal_checker_plugins: ["goal_checker"]
+
     progress_checker:
-      plugin: nav2_controller::SimpleProgressChecker
-      required_movement_radius: 0.5
+      plugin: "nav2_controller::SimpleProgressChecker"
+      required_movement_radius: 0.25
       movement_time_allowance: 10.0
 
-    goal_checker_plugin: goal_checker
     goal_checker:
-      plugin: nav2_controller::SimpleGoalChecker
-      xy_goal_tolerance: 0.1
-      yaw_goal_tolerance: 0.3
-      stateful: true # if stateful is True goal checker will not check if the xy position matches again once it is found to be True.
+      plugin: "nav2_controller::SimpleGoalChecker"
+      stateful: false
+      xy_goal_tolerance: 0.20
+      yaw_goal_tolerance: 0.35
 
-    controller_plugins: [FollowPath]
+    controller_plugins: ["FollowPath"]
     FollowPath:
-      plugin: nav2_regulated_pure_pursuit_controller::RegulatedPurePursuitController
-
-      # Velocity/acceleration limits also have to be adjusted in the velocity smoother
-      desired_linear_vel: 0.4
-      lookahead_dist: 0.5
-      transform_tolerance: 0.25
-
-      # Adaptive lookahead gain
-      use_velocity_scaled_lookahead_dist: false # Currently doesn't work, uncomment in next release
-      lookahead_time: 1.5
-      min_lookahead_dist: 0.3
-      max_lookahead_dist: 0.6
-
-      # Approach to goal
-      min_approach_linear_velocity: 0.2
-      approach_velocity_scaling_dist: 0.5
-
-      # Collision detector
-      use_collision_detection: true
-      max_allowed_time_to_collision_up_to_carrot: 1.0
-
-      # Curvature velocity penalty
-      use_regulated_linear_velocity_scaling: true
-      regulated_linear_scaling_min_radius: 0.5
-
-      # Cost spaces velocity penalty
-      use_cost_regulated_linear_velocity_scaling: true # Whether to use the regulated features for proximity to obstacles (e.g. slow in close proximity to obstacles).
-      cost_scaling_dist: 0.55
-      cost_scaling_gain: 0.8 # Should be <= 1.0
-      inflation_cost_scaling_factor: 3.0
-
-      # Minimum speed in high cost spaces with high curvature
-      regulated_linear_scaling_min_speed: 0.25
-
+      plugin: "nav2_regulated_pure_pursuit_controller::RegulatedPurePursuitController"
+      use_rotate_to_heading: false
       allow_reversing: false
-      use_rotate_to_heading: true
-      rotate_to_heading_min_angle: 0.7
-
-      # it is only used when rotating to heading (use_rotate_to_heading)
-      # for some reason rotate_to_heading_angular_vel is ignored and robot rotates with
-      # max_angular_accel/10. angular velocity (that's why it is set to higher value)
-      max_angular_accel: 7.0
-      rotate_to_heading_angular_vel: 2.5
-      use_interpolation: true
+      desired_linear_vel: 0.50
+      min_approach_linear_velocity: 0.10
+      use_velocity_scaled_lookahead_dist: true
+      min_lookahead_dist: 0.35
+      max_lookahead_dist: 0.80
+      lookahead_time: 1.0
 
 controller_server_rclcpp_node:
   ros__parameters:
@@ -312,23 +281,10 @@ planner_server:
     use_sim_time: false
     expected_planner_frequency: 1.0
 
-    planner_plugins: [GridBased]
+    planner_plugins: ["GridBased"]
     GridBased:
-      plugin: nav2_smac_planner/SmacPlanner2D
-      tolerance: 0.125 # tolerance for planning if unable to reach exact pose, in meters
-      downsample_costmap: false # whether or not to downsample the map
-      downsampling_factor: 1 # multiplier for the resolution of the costmap layer (e.g. 2 on a 5cm costmap would be 10cm)
-      allow_unknown: true # allow traveling in unknown space
-      max_iterations: 500000 # maximum total iterations to search for before failing (in case unreachable), set to -1 to disable
-      max_on_approach_iterations: 500 # maximum number of iterations to attempt to reach goal once in tolerance
-      max_planning_time: 3.0 # max time in s for planner to plan, smooth
-      cost_travel_multiplier: 2.5 # Cost multiplier to apply to search to steer away from high cost areas. Larger values will place in the center of aisles more exactly (if non-`FREE` cost potential field exists) but take slightly longer to compute. To optimize for speed, a value of 1.0 is reasonable. A reasonable tradeoff value is 2.0. A value of 0.0 effective disables steering away from obstacles and acts like a naive binary search A*.
-      use_final_approach_orientation: false # Whether to set the final path pose at the goal's orientation to the requested orientation (false) or in line with the approach angle so the robot doesn't rotate to heading (true)
-      smoother:
-        max_iterations: 500
-        w_smooth: 0.3
-        w_data: 0.2
-        tolerance: 1.0e-6
+      plugin: "nav2_navfn_planner/NavfnPlanner"
+      tolerance: 0.25
 
 planner_server_rclcpp_node:
   ros__parameters:

--- a/justfile
+++ b/justfile
@@ -162,13 +162,16 @@ record-path name:
                  python3 /scripts/path_recorder.py \
                  --output /routes/{{name}}.yaml"
 
-# Reproducir un recorrido con Nav2 (esquiva de obstáculos)
+# Reproducir un recorrido en modo CONTINUO (NavigateThroughPoses)
 play-path name:
-    @echo "Ejecutando recorrido {{name}}"
+    @echo "Ejecutando recorrido {{name}} (continuo, forward, resample=5cm)"
     docker exec -it $(docker compose ps -q path_tools) \
         bash -c "source /opt/ros/humble/setup.bash && \
                  python3 /scripts/path_player.py \
-                 --file /routes/{{name}}.yaml"
+                 --file /routes/{{name}}.yaml \
+                 --mode continuous \
+                 --forward-only \
+                 --resample 0.05"
 # ────────────────────────────────────────────────────────────────
 #  start-route  →  Arranca ROSbot con mapa fijo y reproduce una ruta
 #     Uso:  just start-route mi_ruta        # (omite la extensión .yaml)

--- a/scripts/path_player.py
+++ b/scripts/path_player.py
@@ -1,96 +1,204 @@
 #!/usr/bin/env python3
 """
-Reproduce un recorrido YAML mediante la acción /follow_waypoints.
-Uso:
-  ros2 run path_tools path_player.py --file /routes/nombre.yaml
+Reproduce un recorrido YAML de forma continua (NavigateThroughPoses) o discreta (FollowWaypoints).
+
+Uso típico (continuo, sin paradas, mirando delante):
+  ros2 run path_tools path_player.py --file /routes/nombre.yaml \
+      --mode continuous --forward-only --resample 0.05
 """
-import sys, time, yaml, math, rclpy
+import os, sys, math, yaml, rclpy, time
 from rclpy.node import Node
 from rclpy.action import ActionClient
-from geometry_msgs.msg import PoseStamped, Quaternion
-import geometry_msgs.msg
-from nav2_msgs.action import FollowWaypoints
-from builtin_interfaces.msg import Time as TimeMsg
+from geometry_msgs.msg import PoseStamped, PoseWithCovarianceStamped
+from nav2_msgs.action import NavigateThroughPoses, FollowWaypoints
 
+def quat_from_yaw(yaw):
+    return (0.0, 0.0, math.sin(yaw * 0.5), math.cos(yaw * 0.5))
 
-def quaternion_from_yaw(yaw):
-    """Devuelve (x,y,z,w) para yaw dado (roll=pitch=0)."""
-    half = yaw * 0.5
-    return (0.0, 0.0, math.sin(half), math.cos(half))
+def unwrap(prev, curr):
+    while curr - prev > math.pi:  curr -= 2*math.pi
+    while curr - prev < -math.pi: curr += 2*math.pi
+    return curr
 
+def forward_headings(xy):
+    # Tangente del tramo para cada punto, con desenrollado de ángulos
+    n = len(xy)
+    yaws = []
+    for i in range(n):
+        if i < n-1:
+            dx = xy[i+1][0] - xy[i][0]
+            dy = xy[i+1][1] - xy[i][1]
+        else:
+            dx = xy[i][0] - xy[i-1][0]
+            dy = xy[i][1] - xy[i-1][1]
+        yaws.append(math.atan2(dy, dx))
+    for i in range(1, n):
+        yaws[i] = unwrap(yaws[i-1], yaws[i])
+    return yaws
+
+def resample_polyline(xy, step):
+    if not step or step <= 0.0 or len(xy) < 2:
+        return xy
+    out = [xy[0]]
+    remain = 0.0
+    for i in range(1, len(xy)):
+        x0, y0 = out[-1]
+        x1, y1 = xy[i]
+        seg = math.hypot(x1-x0, y1-y0)
+        if seg < 1e-6:
+            continue
+        ux, uy = (x1-x0)/seg, (y1-y0)/seg
+        dist = seg
+        while dist + remain >= step - 1e-9:
+            take = step - remain
+            x0 += ux * take
+            y0 += uy * take
+            out.append((x0, y0))
+            dist -= take
+            remain = 0.0
+        remain += dist
+    if out[-1] != xy[-1]:
+        out.append(xy[-1])
+    return out
 
 class Player(Node):
-    def __init__(self, yaml_file: str):
+    def __init__(self, yaml_file: str, mode='continuous', forward_only=True, resample=0.05):
         super().__init__("path_player")
-        self.declare_parameter("global_frame", "map")
-        self.global_frame = self.get_parameter("global_frame").value
-        # Cargar YAML
-        self.waypoints = self._load_yaml(yaml_file)
-        self.client = ActionClient(self, FollowWaypoints, "/follow_waypoints")
-        self.get_logger().info(f"Leyendo {yaml_file} – {len(self.waypoints)} puntos")
-        self._send_goal()
+        self.yaml_file = yaml_file
+        self.mode = mode
+        self.forward_only = forward_only
+        self.resample = resample
 
-    # --- YAML → lista PoseStamped ----------------------------------
-    def _load_yaml(self, f):
-        data = yaml.safe_load(open(f))
+        # Clientes de acción
+        self.ntp_client = ActionClient(self, NavigateThroughPoses, "/navigate_through_poses")
+        self.fw_client  = ActionClient(self, FollowWaypoints,       "/follow_waypoints")
+
+        # Cargar YAML → lista de PoseStamped
+        self.poses = self._load_poses(yaml_file)
+
+        # Publicar /initialpose con la orientación del primer tramo (forward)
+        self._publish_initialpose(self.poses[0])
+
+        # Enviar acción
+        if self.mode == 'continuous':
+            self._send_nav_through_poses()
+        else:
+            self._send_follow_waypoints()
+
+    # --- YAML → Poses --------------------------------------------
+    def _load_poses(self, path):
+        data = yaml.safe_load(open(path))
+        wps = data["waypoints"]
+        xy = [(float(w["x"]), float(w["y"])) for w in wps]
+
+        # Re-muestreo para densidad uniforme (evita “huecos”)
+        xy = resample_polyline(xy, self.resample) if self.resample else xy
+
+        # Yaw: por defecto “mirando delante” (tangente)
+        if self.forward_only:
+            yaws = forward_headings(xy)
+        else:
+            # Usa yaw del YAML si existe; si falta, deriva de segmento
+            yaws = []
+            for i, w in enumerate(wps):
+                if "yaw" in w:
+                    yaws.append(float(w["yaw"]))
+                else:
+                    if i < len(wps)-1:
+                        dx = wps[i+1]["x"] - w["x"]; dy = wps[i+1]["y"] - w["y"]
+                    else:
+                        dx = w["x"] - wps[i-1]["x"]; dy = w["y"] - wps[i-1]["y"]
+                    yaws.append(math.atan2(dy, dx))
+
         poses = []
-        for i, w in enumerate(data["waypoints"]):
+        now = self.get_clock().now().to_msg()
+        for (x, y), yaw in zip(xy, yaws):
+            q = quat_from_yaw(yaw)
             ps = PoseStamped()
-            ps.header.frame_id = self.global_frame
-            ps.header.stamp = TimeMsg(sec=0, nanosec=0)
-            ps.pose.position.x = float(w["x"])
-            ps.pose.position.y = float(w["y"])
-            q = quaternion_from_yaw(float(w["yaw"]))
-            ps.pose.orientation = Quaternion(x=q[0], y=q[1], z=q[2], w=q[3])
+            ps.header.frame_id = "map"
+            ps.header.stamp = now
+            ps.pose.position.x = x
+            ps.pose.position.y = y
+            ps.pose.orientation.z = q[2]
+            ps.pose.orientation.w = q[3]
             poses.append(ps)
+        self.get_logger().info(f"Leyendo {path} → {len(poses)} poses (mode={self.mode}, forward_only={self.forward_only}, resample={self.resample} m)")
         return poses
 
-    # --- Acción FollowWaypoints ------------------------------------
-    def _send_goal(self):
-        self.client.wait_for_server()
-        goal_msg = FollowWaypoints.Goal(poses=self.waypoints)
-        self.get_logger().info("🚀  Enviando acción /follow_waypoints …")
-        send_future = self.client.send_goal_async(goal_msg, feedback_callback=self._feedback)
-        send_future.add_done_callback(self._result_cb)
+    # --- Pose inicial --------------------------------------------
+    def _publish_initialpose(self, ps: PoseStamped):
+        msg = PoseWithCovarianceStamped()
+        msg.header.frame_id = "map"
+        msg.pose.pose = ps.pose
+        # Covarianzas: 5 cm y ~5°
+        msg.pose.covariance[0]  = 0.05**2
+        msg.pose.covariance[7]  = 0.05**2
+        msg.pose.covariance[35] = (math.radians(5))**2
+        pub = self.create_publisher(PoseWithCovarianceStamped, "/initialpose", 1)
+        # Publica 3 veces por si algún nodo arranca más tarde
+        for _ in range(3):
+            pub.publish(msg)
+            time.sleep(0.1)
+        self.get_logger().info("📍 Pose inicial publicada")
 
-    def _feedback(self, feedback):
-        idx = feedback.feedback.current_waypoint
-        self.get_logger().debug(f"➡️  Llegando a waypoint {idx}")
+    # --- Acciones -------------------------------------------------
+    def _send_nav_through_poses(self):
+        self.get_logger().info("🚀 /navigate_through_poses (modo continuo)")
+        if not self.ntp_client.wait_for_server(timeout_sec=10.0):
+            self.get_logger().error("⛔ No está disponible /navigate_through_poses")
+            rclpy.shutdown(); return
+        goal = NavigateThroughPoses.Goal()
+        goal.poses = self.poses
+        future = self.ntp_client.send_goal_async(goal, feedback_callback=self._feedback_ntp)
+        future.add_done_callback(self._result_common)
 
-    def _result_cb(self, future):
-        goal_handle = future.result()
-        if not goal_handle.accepted:
-            self.get_logger().error("⛔  Acción rechazada")
-            rclpy.shutdown()
-            return
-        self.get_logger().info("✅  Acción aceptada")
-        res_future = goal_handle.get_result_async()
-        res_future.add_done_callback(
-            lambda *_: (self.get_logger().info("🏁  Recorrido terminado"), rclpy.shutdown())
-        )
+    def _send_follow_waypoints(self):
+        self.get_logger().info("🚀 /follow_waypoints (modo discreto)")
+        if not self.fw_client.wait_for_server(timeout_sec=10.0):
+            self.get_logger().error("⛔ No está disponible /follow_waypoints")
+            rclpy.shutdown(); return
+        goal = FollowWaypoints.Goal()
+        goal.poses = self.poses
+        future = self.fw_client.send_goal_async(goal, feedback_callback=self._feedback_fw)
+        future.add_done_callback(self._result_common)
 
+    # --- Feedback / Result ---------------------------------------
+    def _feedback_ntp(self, fb):
+        # fb.feedback.current_pose, distance_remaining, etc. (según versión)
+        pass
+
+    def _feedback_fw(self, fb):
+        # fb.feedback.current_waypoint
+        pass
+
+    def _result_common(self, future):
+        handle = future.result()
+        if not handle.accepted:
+            self.get_logger().error("⛔ Acción rechazada")
+            rclpy.shutdown(); return
+        self.get_logger().info("✅ Acción aceptada, navegando…")
+        res_fut = handle.get_result_async()
+        res_fut.add_done_callback(lambda *_: (self.get_logger().info("🏁 Recorrido terminado"), rclpy.shutdown()))
 
 def main():
+    # CLI simple compatible con tu --file
     if "--file" not in sys.argv:
-        print("Requiere --file /ruta/archivo.yaml", file=sys.stderr)
+        print("Requiere --file /ruta/archivo.yaml [--mode continuous|discrete] [--forward-only] [--resample 0.05]", file=sys.stderr)
         sys.exit(1)
     yaml_file = sys.argv[sys.argv.index("--file") + 1]
+    # Flags (defaults)
+    mode = "continuous" if "--mode" not in sys.argv else sys.argv[sys.argv.index("--mode")+1]
+    forward_only = ("--forward-only" in sys.argv) or ("--no-forward" not in sys.argv)
+    resample = 0.05
+    if "--resample" in sys.argv:
+        try:
+            resample = float(sys.argv[sys.argv.index("--resample")+1])
+        except Exception:
+            pass
+
     rclpy.init()
-    node = Player(yaml_file)
-
-    # ── NUEVO: publicar pose inicial ────────────────────────────
-    pub = node.create_publisher(
-        geometry_msgs.msg.PoseWithCovarianceStamped, "/initialpose", qos_profile=1
-    )
-    ps0 = node.waypoints[0]                       # primer waypoint
-    ipose = geometry_msgs.msg.PoseWithCovarianceStamped()
-    ipose.header.frame_id = node.global_frame
-    ipose.pose.pose = ps0.pose
-    pub.publish(ipose)
-    node.get_logger().info("📍  Pose inicial publicada")
-
+    node = Player(yaml_file, mode=mode, forward_only=forward_only, resample=resample)
     rclpy.spin(node)
-
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- add new path player with continuous NavigateThroughPoses support, forward heading and polyline resampling
- tune Nav2 RPP parameters to avoid rotation and add Navfn planner
- update play-path recipe for continuous playback by default

## Testing
- `python3 -m py_compile scripts/path_player.py`
- `pre-commit run --files scripts/path_player.py config/nav2_rpp_params.yaml justfile` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b82b485098832380e31502c6e6531d