### PR TITLE
Improve waypoint recording and add navigation retry logic

### DIFF
--- a/scripts/path_player.py
+++ b/scripts/path_player.py
@@ -1,204 +1,227 @@
 #!/usr/bin/env python3
 """
-Reproduce un recorrido YAML de forma continua (NavigateThroughPoses) o discreta (FollowWaypoints).
-
-Uso típico (continuo, sin paradas, mirando delante):
-  ros2 run path_tools path_player.py --file /routes/nombre.yaml \
-      --mode continuous --forward-only --resample 0.05
+Reproduce un recorrido YAML mediante la acción /follow_waypoints.
+Uso:
+  ros2 run path_tools path_player.py --file /routes/nombre.yaml
 """
-import os, sys, math, yaml, rclpy, time
+import sys, time, yaml, math, rclpy
 from rclpy.node import Node
 from rclpy.action import ActionClient
-from geometry_msgs.msg import PoseStamped, PoseWithCovarianceStamped
-from nav2_msgs.action import NavigateThroughPoses, FollowWaypoints
+from geometry_msgs.msg import PoseStamped, Quaternion
+import geometry_msgs.msg
+from nav2_msgs.action import FollowWaypoints
+from builtin_interfaces.msg import Time as TimeMsg
+from action_msgs.msg import GoalStatus
+from std_srvs.srv import Empty
+from nav_msgs.msg import OccupancyGrid
 
-def quat_from_yaw(yaw):
-    return (0.0, 0.0, math.sin(yaw * 0.5), math.cos(yaw * 0.5))
 
-def unwrap(prev, curr):
-    while curr - prev > math.pi:  curr -= 2*math.pi
-    while curr - prev < -math.pi: curr += 2*math.pi
-    return curr
+def quaternion_from_yaw(yaw):
+    """Devuelve (x,y,z,w) para yaw dado (roll=pitch=0)."""
+    half = yaw * 0.5
+    return (0.0, 0.0, math.sin(half), math.cos(half))
 
-def forward_headings(xy):
-    # Tangente del tramo para cada punto, con desenrollado de ángulos
-    n = len(xy)
-    yaws = []
-    for i in range(n):
-        if i < n-1:
-            dx = xy[i+1][0] - xy[i][0]
-            dy = xy[i+1][1] - xy[i][1]
-        else:
-            dx = xy[i][0] - xy[i-1][0]
-            dy = xy[i][1] - xy[i-1][1]
-        yaws.append(math.atan2(dy, dx))
-    for i in range(1, n):
-        yaws[i] = unwrap(yaws[i-1], yaws[i])
-    return yaws
 
-def resample_polyline(xy, step):
-    if not step or step <= 0.0 or len(xy) < 2:
-        return xy
-    out = [xy[0]]
-    remain = 0.0
-    for i in range(1, len(xy)):
-        x0, y0 = out[-1]
-        x1, y1 = xy[i]
-        seg = math.hypot(x1-x0, y1-y0)
-        if seg < 1e-6:
-            continue
-        ux, uy = (x1-x0)/seg, (y1-y0)/seg
-        dist = seg
-        while dist + remain >= step - 1e-9:
-            take = step - remain
-            x0 += ux * take
-            y0 += uy * take
-            out.append((x0, y0))
-            dist -= take
-            remain = 0.0
-        remain += dist
-    if out[-1] != xy[-1]:
-        out.append(xy[-1])
-    return out
+def yaw_from_qzw(qz, qw):
+    # roll=pitch=0 asumido
+    return 2.0 * math.atan2(qz, qw)
+
 
 class Player(Node):
-    def __init__(self, yaml_file: str, mode='continuous', forward_only=True, resample=0.05):
+    def __init__(self, yaml_file: str):
         super().__init__("path_player")
-        self.yaml_file = yaml_file
-        self.mode = mode
-        self.forward_only = forward_only
-        self.resample = resample
+        self.declare_parameter("global_frame", "map")
+        self.global_frame = self.get_parameter("global_frame").value
+        # Cargar YAML
+        self.waypoints = self._load_yaml(yaml_file)
+        self.client = ActionClient(self, FollowWaypoints, "/follow_waypoints")
+        self.get_logger().info(f"Leyendo {yaml_file} – {len(self.waypoints)} puntos")
 
-        # Clientes de acción
-        self.ntp_client = ActionClient(self, NavigateThroughPoses, "/navigate_through_poses")
-        self.fw_client  = ActionClient(self, FollowWaypoints,       "/follow_waypoints")
+        # ---- NUEVO: servicios para limpiar costmaps y mapa estático ----
+        self.clear_local = self.create_client(Empty, "/local_costmap/clear_entirely_local_costmap")
+        self.clear_global = self.create_client(Empty, "/global_costmap/clear_entirely_global_costmap")
+        self.map_msg = None
+        self.create_subscription(OccupancyGrid, "/map", self._on_map, qos_profile=1)
 
-        # Cargar YAML → lista de PoseStamped
-        self.poses = self._load_poses(yaml_file)
+        # Publisher de pose inicial para poder reintentar
+        self.init_pub = self.create_publisher(
+            geometry_msgs.msg.PoseWithCovarianceStamped, "/initialpose", qos_profile=1
+        )
 
-        # Publicar /initialpose con la orientación del primer tramo (forward)
-        self._publish_initialpose(self.poses[0])
+        # Parámetros de reintento
+        self.max_retries = 3
+        self.retry_count = 0
 
-        # Enviar acción
-        if self.mode == 'continuous':
-            self._send_nav_through_poses()
-        else:
-            self._send_follow_waypoints()
+        # Publica pose inicial (con "empuje" hacia delante si hace falta) y lanza goal
+        self._publish_initial_pose_forward()
+        self._clear_costmaps()
+        self._send_goal()
 
-    # --- YAML → Poses --------------------------------------------
-    def _load_poses(self, path):
-        data = yaml.safe_load(open(path))
-        wps = data["waypoints"]
-        xy = [(float(w["x"]), float(w["y"])) for w in wps]
-
-        # Re-muestreo para densidad uniforme (evita “huecos”)
-        xy = resample_polyline(xy, self.resample) if self.resample else xy
-
-        # Yaw: por defecto “mirando delante” (tangente)
-        if self.forward_only:
-            yaws = forward_headings(xy)
-        else:
-            # Usa yaw del YAML si existe; si falta, deriva de segmento
-            yaws = []
-            for i, w in enumerate(wps):
-                if "yaw" in w:
-                    yaws.append(float(w["yaw"]))
-                else:
-                    if i < len(wps)-1:
-                        dx = wps[i+1]["x"] - w["x"]; dy = wps[i+1]["y"] - w["y"]
-                    else:
-                        dx = w["x"] - wps[i-1]["x"]; dy = w["y"] - wps[i-1]["y"]
-                    yaws.append(math.atan2(dy, dx))
-
+    # --- YAML → lista PoseStamped ----------------------------------
+    def _load_yaml(self, f):
+        data = yaml.safe_load(open(f))
         poses = []
-        now = self.get_clock().now().to_msg()
-        for (x, y), yaw in zip(xy, yaws):
-            q = quat_from_yaw(yaw)
+        for i, w in enumerate(data["waypoints"]):
             ps = PoseStamped()
-            ps.header.frame_id = "map"
-            ps.header.stamp = now
-            ps.pose.position.x = x
-            ps.pose.position.y = y
-            ps.pose.orientation.z = q[2]
-            ps.pose.orientation.w = q[3]
+            ps.header.frame_id = self.global_frame
+            ps.header.stamp = TimeMsg(sec=0, nanosec=0)
+            ps.pose.position.x = float(w["x"])
+            ps.pose.position.y = float(w["y"])
+            q = quaternion_from_yaw(float(w["yaw"]))
+            ps.pose.orientation = Quaternion(x=q[0], y=q[1], z=q[2], w=q[3])
             poses.append(ps)
-        self.get_logger().info(f"Leyendo {path} → {len(poses)} poses (mode={self.mode}, forward_only={self.forward_only}, resample={self.resample} m)")
         return poses
 
-    # --- Pose inicial --------------------------------------------
-    def _publish_initialpose(self, ps: PoseStamped):
-        msg = PoseWithCovarianceStamped()
-        msg.header.frame_id = "map"
-        msg.pose.pose = ps.pose
+    # --- Mapa ------------------------------------------------------
+    def _on_map(self, msg: OccupancyGrid):
+        self.map_msg = msg
+
+    def _is_free_on_static(self, x, y):
+        """Devuelve True si (x,y) cae en celda libre (0) del /map; False si desconocido (-1) u ocupada (100)."""
+        m = self.map_msg
+        if m is None:
+            return True  # si aún no llegó el mapa, no bloqueamos
+        res = m.info.resolution
+        ox = m.info.origin.position.x
+        oy = m.info.origin.position.y
+        mx = int((x - ox) / res)
+        my = int((y - oy) / res)
+        if mx < 0 or my < 0 or mx >= m.info.width or my >= m.info.height:
+            return False
+        val = m.data[my * m.info.width + mx]
+        return val == 0
+
+    # --- Pose inicial con pequeño avance hacia delante -------------
+    def _publish_initial_pose_forward(self):
+        ps0 = self.waypoints[0]
+        # vector hacia delante: preferimos segundo punto; si no, usamos yaw del primero
+        if len(self.waypoints) >= 2:
+            dx = self.waypoints[1].pose.position.x - ps0.pose.position.x
+            dy = self.waypoints[1].pose.position.y - ps0.pose.position.y
+            norm = math.hypot(dx, dy) or 1.0
+            fx, fy = dx / norm, dy / norm
+        else:
+            yaw = yaw_from_qzw(ps0.pose.orientation.z, ps0.pose.orientation.w)
+            fx, fy = math.cos(yaw), math.sin(yaw)
+
+        # probamos offsets hacia delante: 0.00, 0.15, 0.30, 0.45, 0.60 m
+        candidates = [0.00, 0.15, 0.30, 0.45, 0.60]
+        x0, y0 = ps0.pose.position.x, ps0.pose.position.y
+        chosen = (x0, y0)
+        for off in candidates:
+            cx, cy = x0 + fx * off, y0 + fy * off
+            if self._is_free_on_static(cx, cy):
+                chosen = (cx, cy)
+                break
+
+        ipose = geometry_msgs.msg.PoseWithCovarianceStamped()
+        ipose.header.frame_id = self.global_frame
+        ipose.pose.pose = ps0.pose
+        ipose.pose.pose.position.x = chosen[0]
+        ipose.pose.pose.position.y = chosen[1]
         # Covarianzas: 5 cm y ~5°
-        msg.pose.covariance[0]  = 0.05**2
-        msg.pose.covariance[7]  = 0.05**2
-        msg.pose.covariance[35] = (math.radians(5))**2
-        pub = self.create_publisher(PoseWithCovarianceStamped, "/initialpose", 1)
-        # Publica 3 veces por si algún nodo arranca más tarde
+        ipose.pose.covariance[0] = 0.05 ** 2
+        ipose.pose.covariance[7] = 0.05 ** 2
+        ipose.pose.covariance[35] = (math.radians(5)) ** 2
         for _ in range(3):
-            pub.publish(msg)
+            self.init_pub.publish(ipose)
             time.sleep(0.1)
-        self.get_logger().info("📍 Pose inicial publicada")
+        if (chosen[0], chosen[1]) != (x0, y0):
+            self.get_logger().info(
+                f"📍 Pose inicial adelantada {math.hypot(chosen[0]-x0, chosen[1]-y0):.2f} m para evitar celda letal."
+            )
+        else:
+            self.get_logger().info("📍 Pose inicial publicada")
 
-    # --- Acciones -------------------------------------------------
-    def _send_nav_through_poses(self):
-        self.get_logger().info("🚀 /navigate_through_poses (modo continuo)")
-        if not self.ntp_client.wait_for_server(timeout_sec=10.0):
-            self.get_logger().error("⛔ No está disponible /navigate_through_poses")
-            rclpy.shutdown(); return
-        goal = NavigateThroughPoses.Goal()
-        goal.poses = self.poses
-        future = self.ntp_client.send_goal_async(goal, feedback_callback=self._feedback_ntp)
-        future.add_done_callback(self._result_common)
+    def _republish_initial_pose_more_forward(self):
+        """En reintentos, probar un poco más de avance."""
+        self.get_logger().warn("Reintentando: adelantando pose inicial +0.25 m")
+        # Avanza 0.25 m adicionales desde el primer punto
+        ps0 = self.waypoints[0]
+        if len(self.waypoints) >= 2:
+            dx = self.waypoints[1].pose.position.x - ps0.pose.position.x
+            dy = self.waypoints[1].pose.position.y - ps0.pose.position.y
+            norm = math.hypot(dx, dy) or 1.0
+            fx, fy = dx / norm, dy / norm
+        else:
+            yaw = yaw_from_qzw(ps0.pose.orientation.z, ps0.pose.orientation.w)
+            fx, fy = math.cos(yaw), math.sin(yaw)
+        bump = 0.25 * self.retry_count
+        ipose = geometry_msgs.msg.PoseWithCovarianceStamped()
+        ipose.header.frame_id = self.global_frame
+        ipose.pose.pose = ps0.pose
+        ipose.pose.pose.position.x = ps0.pose.position.x + fx * bump
+        ipose.pose.pose.position.y = ps0.pose.position.y + fy * bump
+        self.init_pub.publish(ipose)
+        time.sleep(0.1)
 
-    def _send_follow_waypoints(self):
-        self.get_logger().info("🚀 /follow_waypoints (modo discreto)")
-        if not self.fw_client.wait_for_server(timeout_sec=10.0):
-            self.get_logger().error("⛔ No está disponible /follow_waypoints")
-            rclpy.shutdown(); return
-        goal = FollowWaypoints.Goal()
-        goal.poses = self.poses
-        future = self.fw_client.send_goal_async(goal, feedback_callback=self._feedback_fw)
-        future.add_done_callback(self._result_common)
+    def _clear_costmaps(self):
+        for client, name in [(self.clear_local, "local"), (self.clear_global, "global")]:
+            if client.wait_for_service(timeout_sec=1.0):
+                try:
+                    client.call_async(Empty.Request())
+                except Exception:
+                    pass
+            else:
+                self.get_logger().warn(f"No disponible clear_entirely_{name}_costmap")
 
-    # --- Feedback / Result ---------------------------------------
-    def _feedback_ntp(self, fb):
-        # fb.feedback.current_pose, distance_remaining, etc. (según versión)
-        pass
+    # --- Acción FollowWaypoints ------------------------------------
+    def _send_goal(self):
+        self.client.wait_for_server()
+        goal_msg = FollowWaypoints.Goal(poses=self.waypoints)
+        self.get_logger().info("🚀  Enviando acción /follow_waypoints …")
+        send_future = self.client.send_goal_async(goal_msg, feedback_callback=self._feedback)
+        send_future.add_done_callback(self._goal_response_cb)
 
-    def _feedback_fw(self, fb):
-        # fb.feedback.current_waypoint
-        pass
+    def _goal_response_cb(self, future):
+        goal_handle = future.result()
+        if not goal_handle.accepted:
+            self.get_logger().error("⛔  Acción rechazada")
+            self._retry_or_finish()
+            return
+        self.get_logger().info("✅  Acción aceptada")
+        res_future = goal_handle.get_result_async()
+        res_future.add_done_callback(self._on_result)
 
-    def _result_common(self, future):
-        handle = future.result()
-        if not handle.accepted:
-            self.get_logger().error("⛔ Acción rechazada")
-            rclpy.shutdown(); return
-        self.get_logger().info("✅ Acción aceptada, navegando…")
-        res_fut = handle.get_result_async()
-        res_fut.add_done_callback(lambda *_: (self.get_logger().info("🏁 Recorrido terminado"), rclpy.shutdown()))
+    def _feedback(self, feedback):
+        idx = feedback.feedback.current_waypoint
+        self.get_logger().debug(f"➡️  Llegando a waypoint {idx}")
+
+    def _on_result(self, future):
+        resp = future.result()
+        status = getattr(resp, "status", GoalStatus.STATUS_UNKNOWN)
+        if status == GoalStatus.STATUS_SUCCEEDED:
+            self.get_logger().info("🏁  Recorrido terminado (SUCCESS)")
+            rclpy.shutdown()
+            return
+        # Si falló (abort/cancel/unknown), reintenta: limpiar, adelantar pose y volver a enviar
+        self.get_logger().warn(
+            f"⚠️  Goal terminó con estado {status}. Intentando recuperación…"
+        )
+        self._retry_or_finish()
+
+    def _retry_or_finish(self):
+        if self.retry_count >= self.max_retries:
+            self.get_logger().error("⛔  Reintentos agotados. Recorrido terminado.")
+            rclpy.shutdown()
+            return
+        self.retry_count += 1
+        self._clear_costmaps()
+        self._republish_initial_pose_more_forward()
+        time.sleep(0.2)
+        self._send_goal()
+
 
 def main():
-    # CLI simple compatible con tu --file
     if "--file" not in sys.argv:
-        print("Requiere --file /ruta/archivo.yaml [--mode continuous|discrete] [--forward-only] [--resample 0.05]", file=sys.stderr)
+        print("Requiere --file /ruta/archivo.yaml", file=sys.stderr)
         sys.exit(1)
     yaml_file = sys.argv[sys.argv.index("--file") + 1]
-    # Flags (defaults)
-    mode = "continuous" if "--mode" not in sys.argv else sys.argv[sys.argv.index("--mode")+1]
-    forward_only = ("--forward-only" in sys.argv) or ("--no-forward" not in sys.argv)
-    resample = 0.05
-    if "--resample" in sys.argv:
-        try:
-            resample = float(sys.argv[sys.argv.index("--resample")+1])
-        except Exception:
-            pass
-
     rclpy.init()
-    node = Player(yaml_file, mode=mode, forward_only=forward_only, resample=resample)
+    node = Player(yaml_file)
     rclpy.spin(node)
+
 
 if __name__ == "__main__":
     main()
+

--- a/scripts/path_recorder.py
+++ b/scripts/path_recorder.py
@@ -18,7 +18,7 @@ def yaw_from_quaternion(q):
     cosy_cosp = 1.0 - 2.0 * (y * y + z * z)
     return math.atan2(siny_cosp, cosy_cosp)
 
-DIST_THRESHOLD = 0.10  # metros entre muestras
+DIST_THRESHOLD = 0.80  # metros entre muestras
 
 
 class Recorder(Node):


### PR DESCRIPTION
## Summary
- record path points every 0.80 m
- add recovery behavior to `path_player.py` that clears costmaps, adjusts the initial pose forward, and retries failed navigation goals up to three times

## Testing
- `python -m py_compile scripts/path_recorder.py scripts/path_player.py`
- `pip install pre-commit` *(failed: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b8329497a88323af22b3d4485f2a64