### PR TITLE
Use stable RPLIDAR device mapping

### DIFF
--- a/.env
+++ b/.env
@@ -2,6 +2,10 @@
 # Hardware config
 # =======================================
 
+# Stable RPLIDAR device mapping
+RPLIDAR_BYID=/dev/serial/by-id/usb-Silicon_Labs_CP2102N_USB_to_UART_Bridge_Controller_e6b5eba20a77ed119ad9f0fafdf7b791-if00-port0
+RPLIDAR_PORT=/dev/rplidar
+
 # Select LIDAR baudrate:
 # - 1000000 - for RPlidar S2 and S3
 # - 256000 - for RPlidar S1, A2M12 and A3 (violet circle around the sensor)

--- a/compose.yaml
+++ b/compose.yaml
@@ -23,14 +23,13 @@ services:
   rplidar:
     image: husarion/rplidar:humble-1.0.1-20240104
     restart: unless-stopped
-
-    # Usa el puerto que acabamos de comprobar
+    # Puerto estable: by-id → alias interno /dev/rplidar
     devices:
-      - /dev/ttyUSB1:/dev/ttyUSB1
+      - ${RPLIDAR_BYID:-/dev/ttyUSB0}:/dev/rplidar
 
     command: >
       ros2 launch /husarion_utils/rplidar.launch.py
-        serial_port:=/dev/ttyUSB1
+        serial_port:=${RPLIDAR_PORT:-/dev/rplidar}
         serial_baudrate:=1000000
 
     environment: [ROS_DOMAIN_ID=0]
@@ -39,17 +38,15 @@ services:
              "bash -c 'source /opt/ros/humble/setup.bash && ros2 topic list | grep -q ^/scan$'"]
       interval: 30s
       timeout: 5s
-      start_period: 40s
+      start_period: 90s
       retries: 10
 
   navigation:
     image: husarion/navigation2:humble-1.1.12-20240123
     restart: unless-stopped
     depends_on:
-      rplidar:
-        condition: service_healthy
-      rosbot:
-        condition: service_healthy
+      rplidar: { condition: service_started }
+      rosbot:  { condition: service_healthy }
     volumes:
       - ./config/nav2_${CONTROLLER:-rpp}_params.yaml:/params.yaml
       - ./maps:/maps


### PR DESCRIPTION
## Summary
- Map RPLIDAR using persistent by-id path and expose as /dev/rplidar
- Parameterize rplidar launch port and relax health check startup time
- Let navigation start without waiting for rplidar health

## Testing
- `pre-commit run --files .env compose.yaml` *(fails: command not found)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*

------
https://chatgpt.com/codex/tasks/task_e_68b8a6b384bc83239030aac6222da741