### PR TITLE
fix: correct navigation service indentation and default MAP

### DIFF
--- a/.env
+++ b/.env
@@ -41,3 +41,5 @@ CONTROLLER=mppi
 
 # Robot namespace should be the same as Husarnet device name
 ROBOT_NAMESPACE=rosbotxl
+
+MAP=r1

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,5 +1,6 @@
 services:
 
+  # --- ROSBOT (drivers + OAK) ---
   rosbot:
     image: husarion/rosbot-xl:humble-0.10.0-20240202
     network_mode: host
@@ -41,23 +42,24 @@ services:
       start_period: 90s
       retries: 10
 
-    navigation:
-      image: husarion/navigation2:humble-1.1.12-20240123
-      restart: unless-stopped
-      depends_on:
-        rplidar: { condition: service_started }
-        rosbot:  { condition: service_healthy }
-      volumes:
-        - ./config/nav2_${CONTROLLER:-rpp}_params.yaml:/params.yaml
-        - ./maps:/maps
-      environment:
-        - MAP=${MAP:-r1}
-      command: >
-        ros2 launch /husarion_utils/bringup_launch.py
-          slam:=${SLAM:-True}
-          params_file:=/params.yaml
-          map:=/maps/${MAP}.yaml
-          use_sim_time:=False
+  # --- NAVIGATION (Nav2) ---   <<<<  OJO: ahora está al MISMO NIVEL que rplidar
+  navigation:
+    image: husarion/navigation2:humble-1.1.12-20240123
+    restart: unless-stopped
+    depends_on:
+      rplidar: { condition: service_started }
+      rosbot:  { condition: service_healthy }
+    volumes:
+      - ./config/nav2_${CONTROLLER:-rpp}_params.yaml:/params.yaml
+      - ./maps:/maps
+    environment:
+      - MAP=${MAP:-r1}
+    command: >
+      ros2 launch /husarion_utils/bringup_launch.py
+        slam:=${SLAM:-True}
+        params_file:=/params.yaml
+        map:=/maps/${MAP:-r1}.yaml
+        use_sim_time:=False
 
   path_tools:
     image: husarion/navigation2:humble-1.1.12-20240123


### PR DESCRIPTION
## Summary
- move navigation to proper top-level service in compose.yaml
- ensure map uses r1 by default when MAP env is unset
- set MAP=r1 in .env to silence warnings

## Testing
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*
- `docker compose -f compose.yaml config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bad76aa5e08323a49bc2f091a445c7