### PR TITLE
Add overlay to disable OAK for rosbot

### DIFF
--- a/docker-compose.oak-off.yml
+++ b/docker-compose.oak-off.yml
@@ -1,0 +1,5 @@
+services:
+  rosbot:
+    command: >
+      ros2 launch rosbot_xl_bringup bringup.launch.py
+        mecanum:=${MECANUM:-True}


### PR DESCRIPTION
## Summary
- add docker-compose overlay to disable OAK sensor

## Testing
- `pre-commit run --files docker-compose.oak-off.yml` *(fails: command not found)*
- `pip install pre-commit` *(fails: No matching distribution found)*
- `docker compose config -f compose.yaml -f docker-compose.oak-off.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bae329143c83239609864715942dfe