### PR TITLE
Add route compose overlay and update start-route recipe

### DIFF
--- a/compose.route.yml
+++ b/compose.route.yml
@@ -1,0 +1,11 @@
+# compose.route.yml
+services:
+  # 1) Rosbot SIN la OAK (mismo bringup pero sin depthai_params_file)
+  rosbot:
+    command: >
+      ros2 launch rosbot_xl_bringup bringup.launch.py
+        mecanum:=${MECANUM:-True}
+
+  # 2) Que explore_lite NO se arranque en modo rutas
+  explore_lite:
+    profiles: ["explore"]

--- a/justfile
+++ b/justfile
@@ -173,9 +173,9 @@ play-path name:
 # ────────────────────────────────────────────────────────────────
 start-route ruta="r1":
     # 1) Levanta sólo compose.yaml (sin el override ⇒ no arranca teleop)
-    @SLAM=False MAP=${MAP:-r1} docker compose -f compose.yaml up -d
+    @SLAM=False MAP=${MAP:-r1} docker compose -f compose.yaml -f compose.route.yml up -d rosbot rplidar microros navigation path_tools foxglove foxglove-ds
     # Evitar que explore_lite pre-empte los goals del player
-    @docker compose stop explore_lite || true
+    @true
 
     # 2) Espera a que el servicio navigation aparezca sano (máx 60 s)
     @echo "⌛  Esperando a Nav2..."


### PR DESCRIPTION
## Summary
- Add compose.route.yml overlay with rosbot command without OAK and explore_lite profile
- Update start-route to use new overlay and skip stopping explore_lite

## Testing
- ⚠️ `just pre-commit` (command not found and installation failed: apt/pip 403)

------
https://chatgpt.com/codex/tasks/task_e_68baebeb54ac8323a871645048f7f82a