### PR TITLE
feat: make exploration optional

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -101,6 +101,7 @@ services:
         condition: service_started
 
   explore_lite:
+    profiles: ["explore"]
     build:
       context: .
       dockerfile: Dockerfile.explore_lite

--- a/justfile
+++ b/justfile
@@ -174,8 +174,7 @@ play-path name:
 start-route ruta="r1":
     # 1) Levanta sólo compose.yaml (sin el override ⇒ no arranca teleop)
     @SLAM=False MAP=${MAP:-r1} docker compose -f compose.yaml up -d
-    # Evitar que explore_lite pre-empte los goals del player
-    @docker compose stop explore_lite || true
+    # explore_lite no arranca por defecto (profiles: ["explore"])
 
     # 2) Espera a que el servicio navigation aparezca sano (máx 60 s)
     @echo "⌛  Esperando a Nav2..."
@@ -249,3 +248,11 @@ oak-tf:
       timeout 3 ros2 run tf2_ros tf2_echo base_link oak_rgb_camera_optical_frame || true && \
       timeout 3 ros2 run tf2_ros tf2_echo map base_link || true \
     '
+
+# Arrancar explore_lite (perfil 'explore') cuando quieras explorar el mapa
+explore-start:
+    COMPOSE_PROFILES=explore docker compose -f compose.yaml up -d explore_lite
+
+# Parar explore_lite si lo dejaste encendido
+explore-stop:
+    docker compose stop explore_lite || true


### PR DESCRIPTION
## Summary
- prevent `explore_lite` from starting automatically by moving it under an optional `explore` profile
- simplify `start-route` and add `explore-start` / `explore-stop` justfile recipes

## Testing
- `just pre-commit` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*
- `pip install pre-commit` *(fails: 403 proxy error)*

------
https://chatgpt.com/codex/tasks/task_e_68c02bdc344c83239c1ee9d0b37008d9