### PR TITLE
Map USB bus into rosbot container

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -5,6 +5,8 @@ services:
     image: husarion/rosbot-xl:humble-0.10.0-20240202
     network_mode: host
     privileged: true
+    devices:
+      - /dev/bus/usb:/dev/bus/usb
     restart: unless-stopped
     environment: [ ROS_DOMAIN_ID=0 ]
     volumes:

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -8,6 +8,8 @@ services:
     image: husarion/rosbot-xl:humble-0.10.0-20240202
     network_mode: host
     privileged: true
+    devices:
+      - /dev/bus/usb:/dev/bus/usb
     restart: unless-stopped
     environment: [ ROS_DOMAIN_ID=0 ]
     volumes:


### PR DESCRIPTION
## Summary
- map the host USB bus into the rosbot container so the camera is accessible
- ensure teleop override maps the USB bus as well

## Testing
- `pre-commit run --files compose.yaml docker-compose.override.yml` *(fails: pre-commit not installed)*
- `pip install pre-commit` *(fails: Could not connect to proxy)*
- `apt-get update` *(fails: repository not signed / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c164e31fc8832380c966f03fdc1914