### PR TITLE
Start OAK overlay services by default

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -103,6 +103,30 @@ services:
       rplidar:
         condition: service_started
 
+  static_tf:
+    image: husarion/rosbot-xl:humble-0.10.0-20240202
+    network_mode: host
+    restart: unless-stopped
+    environment: [ ROS_DOMAIN_ID=0 ]
+    command: [ "ros2", "run", "tf2_ros", "static_transform_publisher",
+               "0.12", "0.00", "0.20",
+               "0", "0", "0",
+               "base_link", "oak_rgb_camera_optical_frame" ]
+
+  overlay:
+    image: husarion/rosbot-xl:humble-0.10.0-20240202
+    network_mode: host
+    restart: unless-stopped
+    environment: [ ROS_DOMAIN_ID=0 ]
+    volumes:
+      - ./scripts/lidar_overlay.py:/overlay.py:ro
+    command: [ "bash", "-c",
+               "apt-get update -qq && apt-get install -y python3-opencv && \
+                python3 /overlay.py" ]
+    depends_on:
+      static_tf:
+        condition: service_started
+
   explore_lite:
     profiles: ["explore"]
     build:

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -67,33 +67,3 @@ services:
   ###############################################################
   # foxglove  se queda tal y como está en tu compose.yaml
 
-###############################################################
-# 7) Static transform  (láser 20 cm detrás, 30 cm arriba)
-###############################################################
-  static_tf:
-    image: husarion/rosbot-xl:humble-0.10.0-20240202
-    network_mode: host
-    restart: unless-stopped
-    environment: [ ROS_DOMAIN_ID=0 ]
-    command: [ "ros2", "run", "tf2_ros", "static_transform_publisher",
-               "0.12", "0.00", "0.20",         # x  y  z  (ajusta a tu montaje real)
-               "0", "0", "0",                  # roll  pitch  yaw
-               "base_link", "oak_rgb_camera_optical_frame" ]
-
-###############################################################
-# 8) Overlay  (imagen OAK + puntos RPLIDAR)
-###############################################################
-  overlay:
-    image: husarion/rosbot-xl:humble-0.10.0-20240202
-    network_mode: host
-    restart: unless-stopped
-    environment: [ ROS_DOMAIN_ID=0 ]
-    volumes:
-      - ./scripts/lidar_overlay.py:/overlay.py:ro
-    command: [ "bash", "-c",
-               "apt-get update -qq && apt-get install -y python3-opencv && \
-                python3 /overlay.py" ]
-    depends_on:
-      static_tf:
-        condition: service_started
-


### PR DESCRIPTION
## Summary
- Launch static transform and LiDAR overlay services from the base compose so the OAK camera initializes for all Just tasks
- Clean override compose by removing redundant OAK services

## Testing
- `pre-commit run -a` *(fails: command not found)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c198ff7348832383d98d1eeb8c4595