### PR TITLE
Revert OAK camera setup for teleop

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -103,30 +103,6 @@ services:
       rplidar:
         condition: service_started
 
-  static_tf:
-    image: husarion/rosbot-xl:humble-0.10.0-20240202
-    network_mode: host
-    restart: unless-stopped
-    environment: [ ROS_DOMAIN_ID=0 ]
-    command: [ "ros2", "run", "tf2_ros", "static_transform_publisher",
-               "0.12", "0.00", "0.20",
-               "0", "0", "0",
-               "base_link", "oak_rgb_camera_optical_frame" ]
-
-  overlay:
-    image: husarion/rosbot-xl:humble-0.10.0-20240202
-    network_mode: host
-    restart: unless-stopped
-    environment: [ ROS_DOMAIN_ID=0 ]
-    volumes:
-      - ./scripts/lidar_overlay.py:/overlay.py:ro
-    command: [ "bash", "-c",
-               "apt-get update -qq && apt-get install -y python3-opencv && \
-                python3 /overlay.py" ]
-    depends_on:
-      static_tf:
-        condition: service_started
-
   explore_lite:
     profiles: ["explore"]
     build:

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -67,3 +67,33 @@ services:
   ###############################################################
   # foxglove  se queda tal y como está en tu compose.yaml
 
+###############################################################
+# 7) Static transform  (láser 20 cm detrás, 30 cm arriba)
+###############################################################
+  static_tf:
+    image: husarion/rosbot-xl:humble-0.10.0-20240202
+    network_mode: host
+    restart: unless-stopped
+    environment: [ ROS_DOMAIN_ID=0 ]
+    command: [ "ros2", "run", "tf2_ros", "static_transform_publisher",
+               "0.12", "0.00", "0.20",         # x  y  z  (ajusta a tu montaje real)
+               "0", "0", "0",                  # roll  pitch  yaw
+               "base_link", "oak_rgb_camera_optical_frame" ]
+
+###############################################################
+# 8) Overlay  (imagen OAK + puntos RPLIDAR)
+###############################################################
+  overlay:
+    image: husarion/rosbot-xl:humble-0.10.0-20240202
+    network_mode: host
+    restart: unless-stopped
+    environment: [ ROS_DOMAIN_ID=0 ]
+    volumes:
+      - ./scripts/lidar_overlay.py:/overlay.py:ro
+    command: [ "bash", "-c",
+               "apt-get update -qq && apt-get install -y python3-opencv && \
+                python3 /overlay.py" ]
+    depends_on:
+      static_tf:
+        condition: service_started
+


### PR DESCRIPTION
## Summary
- revert the merge of PR #107 to restore the compose defaults without the OAK static TF and overlay services
- move the OAK static_tf and overlay services back into docker-compose.override.yml for optional use

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9bbffa5788323b45ccb23fef8ce42