### PR TITLE
Use 720p OAK configuration with shared mount

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -10,12 +10,12 @@ services:
     restart: unless-stopped
     environment: [ ROS_DOMAIN_ID=0 ]
     volumes:
-      - ./config/oak_1080p.yaml:/config/oak_1080p.yaml:ro
+      - ./config/oak_720p.yaml:/config/oak_params.yaml:ro
     command: >
       ros2 launch rosbot_xl_bringup bringup.launch.py
         mecanum:=${MECANUM:-True}
         depthai:=True
-        depthai_params_file:=/config/oak_1080p.yaml
+        depthai_params_file:=/config/oak_params.yaml
 
   microros:
     image: husarion/micro-ros-agent:humble-3.1.3-20240126

--- a/config/oak_720p.yaml
+++ b/config/oak_720p.yaml
@@ -1,0 +1,24 @@
+camera:
+  ros__parameters:
+    pipeline_type: "RGB"
+
+    # Mantener stream aunque no haya suscriptores:
+    i_enable_lazy_publisher: false
+
+    # Fuerza menor carga:
+    color:
+      i_enable: true
+      i_resolution: 720     # en lugar de 1080
+      i_fps: 15             # baja a 15 FPS
+      publish_raw_images: true
+
+    # Desactiva estéreo/NN por ahora:
+    stereo:
+      i_enable: false
+    rectify:
+      i_enable: false
+    spatial_nn:
+      i_enable: false
+
+    # (Opcional si hay X_LINK_ERROR persistente)
+    # i_usb_speed: "usb2"

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -14,12 +14,12 @@ services:
     environment: [ ROS_DOMAIN_ID=0 ]
     volumes:
       - ./maps:/maps
-      - ./config/oak_1080p.yaml:/config/oak_1080p.yaml:ro
+      - ./config/oak_720p.yaml:/config/oak_params.yaml:ro
     command: >
       ros2 launch rosbot_xl_bringup bringup.launch.py
         mecanum:=${MECANUM:-True}
         depthai:=True
-        depthai_params_file:=/config/oak_1080p.yaml
+        depthai_params_file:=/config/oak_params.yaml
 
   ###############################################################
   # 2) teleop_twist_keyboard (mover el robot)


### PR DESCRIPTION
## Summary
- add a 720p DepthAI configuration that keeps the stream active while reducing load
- point rosbot services to the new config via a consistent /config/oak_params.yaml mount in compose files

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9d82ec3248323a5679c1701efcca8