### PR TITLE
Restore lidar env vars and recorder shutdown

### DIFF
--- a/.env
+++ b/.env
@@ -8,6 +8,10 @@
 # - 115200 - for RPlidar A2M8 (red circle around the sensor)
 LIDAR_BAUDRATE=1000000
 
+# Stable RPLIDAR device mapping
+RPLIDAR_BYID=/dev/serial/by-id/usb-Silicon_Labs_CP2102N_USB_to_UART_Bridge_Controller_e6b5eba20a77ed119ad9f0fafdf7b791-if00-port0
+RPLIDAR_PORT=/dev/rplidar
+
 # Select wheel type:
 # - True - mecanum wheels
 # - False - regular
@@ -21,6 +25,9 @@ MECANUM=False
 # - True - with mapping
 # - False - without mapping
 SLAM=True
+
+# Mapa por defecto (usado por compose/navigation)
+MAP=r1
 
 # Period of time for autosave map. Work only when SLAM=True (set 0 to disable)
 SAVE_MAP_PERIOD=15

--- a/compose.yaml
+++ b/compose.yaml
@@ -23,41 +23,38 @@ services:
   rplidar:
     image: husarion/rplidar:humble-1.0.1-20240104
     restart: unless-stopped
-
-    # Usa el puerto que acabamos de comprobar
     devices:
-      - /dev/ttyUSB1:/dev/ttyUSB1
-
+      - ${RPLIDAR_BYID:-/dev/ttyUSB0}:/dev/rplidar
     command: >
       ros2 launch /husarion_utils/rplidar.launch.py
-        serial_port:=/dev/ttyUSB1
-        serial_baudrate:=1000000
+        serial_port:=${RPLIDAR_PORT:-/dev/rplidar}
+        serial_baudrate:=${LIDAR_BAUDRATE:-1000000}
 
-    environment: [ROS_DOMAIN_ID=0]
+    environment: [ ROS_DOMAIN_ID=0 ]
     healthcheck:
       test: ["CMD-SHELL",
              "bash -c 'source /opt/ros/humble/setup.bash && ros2 topic list | grep -q ^/scan$'"]
       interval: 30s
       timeout: 5s
-      start_period: 40s
+      start_period: 90s
       retries: 10
 
   navigation:
     image: husarion/navigation2:humble-1.1.12-20240123
     restart: unless-stopped
     depends_on:
-      rplidar:
-        condition: service_healthy
-      rosbot:
-        condition: service_healthy
+      rplidar: { condition: service_started }
+      rosbot:  { condition: service_started }
     volumes:
       - ./config/nav2_${CONTROLLER:-rpp}_params.yaml:/params.yaml
       - ./maps:/maps
+    environment:
+      - MAP=${MAP:-r1}
     command: >
       ros2 launch /husarion_utils/bringup_launch.py
         slam:=${SLAM:-True}
         params_file:=/params.yaml
-        map:=/maps/almacen_nuevo.yaml
+        map:=/maps/${MAP:-r1}.yaml
         use_sim_time:=False
 
   path_tools:
@@ -106,6 +103,7 @@ services:
       dockerfile: Dockerfile.explore_lite
     network_mode: host
     restart: unless-stopped
+    profiles: ["explore"]
     volumes:
       - ./config/explore_params.yaml:/opt/explore_ws/explore_params.yaml:ro
     depends_on:

--- a/scripts/path_recorder.py
+++ b/scripts/path_recorder.py
@@ -1,11 +1,18 @@
 #!/usr/bin/env python3
-"""
-Graba waypoints a partir de /amcl_pose mientras el robot se mueve.
+"""Graba waypoints a partir de /amcl_pose mientras el robot se mueve.
+
 Uso:
-  ros2 run path_tools path_recorder.py --output /routes/nombre.yaml
+    ros2 run path_tools path_recorder.py --output /routes/nombre.yaml
+
 Se detiene con Ctrl‑C.
 """
-import sys, math, yaml, signal, rclpy
+
+import math
+import signal
+import sys
+
+import rclpy
+import yaml
 from rclpy.node import Node
 from geometry_msgs.msg import PoseWithCovarianceStamped
 
@@ -18,7 +25,7 @@ def yaw_from_quaternion(q):
     cosy_cosp = 1.0 - 2.0 * (y * y + z * z)
     return math.atan2(siny_cosp, cosy_cosp)
 
-DIST_THRESHOLD = 0.10  # metros entre muestras
+DIST_THRESHOLD = 0.80  # metros entre muestras
 
 
 class Recorder(Node):
@@ -27,6 +34,7 @@ class Recorder(Node):
         self.out_file = out_file
         self.last_pose = None
         self.path = []
+        self._shutdown = False
         self.create_subscription(
             PoseWithCovarianceStamped, "/amcl_pose", self.on_pose, qos_profile=10
         )
@@ -54,24 +62,42 @@ class Recorder(Node):
 
     # --- finish ----------------------------------------------------
     def shutdown(self):
+        if self._shutdown:
+            return
+        self._shutdown = True
         if not self.path:
             self.get_logger().warn("Ningún punto grabado; fichero vacío.")
             return
-        yaml.safe_dump({"waypoints": self.path}, open(self.out_file, "w"), sort_keys=False)
+        with open(self.out_file, "w", encoding="utf-8") as handle:
+            yaml.safe_dump({"waypoints": self.path}, handle, sort_keys=False)
         self.get_logger().info(f"⏹️  Guardado {len(self.path)} puntos → {self.out_file}")
 
 
-def main():
+def parse_output_arg() -> str:
     if "--output" not in sys.argv:
         print("Requiere --output /ruta/archivo.yaml", file=sys.stderr)
         sys.exit(1)
-    out_file = sys.argv[sys.argv.index("--output") + 1]
-    rclpy.init()
-    node = Recorder(out_file)
-    # Ctrl‑C clean
-    signal.signal(signal.SIGINT, lambda *_: node.shutdown() or sys.exit(0))
-    rclpy.spin(node)
+    return sys.argv[sys.argv.index("--output") + 1]
 
 
 if __name__ == "__main__":
-    main()
+    out_file = parse_output_arg()
+    rclpy.init()
+    recorder = Recorder(out_file)
+
+    def _handle_sigint(*_args):
+        recorder.shutdown()
+        if rclpy.ok():
+            rclpy.shutdown()
+        sys.exit(0)
+
+    signal.signal(signal.SIGINT, _handle_sigint)
+    try:
+        rclpy.spin(recorder)
+    except SystemExit:
+        pass
+    finally:
+        recorder.shutdown()
+        recorder.destroy_node()
+        if rclpy.ok():
+            rclpy.shutdown()


### PR DESCRIPTION
## Summary
- restore the RPLIDAR device mapping and default map variables in `.env` and wire them through `compose.yaml`
- point the navigation bringup to the selected map, depend only on service start, and keep explore-lite behind its profile
- harden the path recorder by keeping the larger sampling threshold and ensuring Ctrl-C triggers a single clean shutdown

## Testing
- `pre-commit run --all-files` *(fails: `pre-commit` is unavailable in the container and installation is blocked by the proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68ca8f266b088323a62caa7ce0ea03b4