### PR TITLE
Ensure path recorder handles Ctrl-C via finally block

### DIFF
--- a/justfile
+++ b/justfile
@@ -156,11 +156,10 @@ teleop:
 
 # Grabar un recorrido con teleoperación activa
 record-path name:
-    @echo "Grabando recorrido {{name}} –\u00a0pulsa Ctrl-C para terminar"
-    docker exec -it $(docker compose ps -q path_tools) \
-        bash -c "source /opt/ros/humble/setup.bash && \
-                 python3 /scripts/path_recorder.py \
-                 --output /routes/{{name}}.yaml"
+    @echo "Grabando recorrido {{name}} — pulsa Ctrl-C para terminar"
+    docker compose exec -it path_tools bash -lc \
+      "source /opt/ros/humble/setup.bash && \
+       python3 /scripts/path_recorder.py --output /routes/{{name}}.yaml"
 
 # Reproducir un recorrido con Nav2 (esquiva de obstáculos)
 play-path name:

--- a/scripts/path_recorder.py
+++ b/scripts/path_recorder.py
@@ -8,7 +8,6 @@ Se detiene con Ctrl‑C.
 """
 
 import math
-import signal
 import sys
 
 import rclpy
@@ -84,20 +83,11 @@ if __name__ == "__main__":
     out_file = parse_output_arg()
     rclpy.init()
     recorder = Recorder(out_file)
-
-    def _handle_sigint(*_args):
-        recorder.shutdown()
-        if rclpy.ok():
-            rclpy.shutdown()
-        sys.exit(0)
-
-    signal.signal(signal.SIGINT, _handle_sigint)
     try:
         rclpy.spin(recorder)
-    except SystemExit:
+    except KeyboardInterrupt:
         pass
     finally:
         recorder.shutdown()
         recorder.destroy_node()
-        if rclpy.ok():
-            rclpy.shutdown()
+        rclpy.shutdown()


### PR DESCRIPTION
## Summary
- ensure `path_recorder` relies on try/except/finally to handle Ctrl-C and always call shutdown
- update the `record-path` recipe to use `docker compose exec` with a login shell so Ctrl-C propagates into the container

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ca9eca2d748323b1adda3ff45d9dbe