### PR TITLE
Adjust waypoint distance threshold

### DIFF
--- a/scripts/path_recorder.py
+++ b/scripts/path_recorder.py
@@ -24,7 +24,7 @@ def yaw_from_quaternion(q):
     cosy_cosp = 1.0 - 2.0 * (y * y + z * z)
     return math.atan2(siny_cosp, cosy_cosp)
 
-DIST_THRESHOLD = 0.80  # metros entre muestras
+DIST_THRESHOLD = 0.35  # metros entre muestras
 
 
 class Recorder(Node):


### PR DESCRIPTION
## Summary
- update the waypoint recorder distance threshold to 0.35 m to capture denser paths

## Testing
- no tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cad8f8dc0883238b4757db76e58ce8