### PR TITLE
Adjust costmaps and startup behavior

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -45,6 +45,7 @@ services:
     restart: unless-stopped
     depends_on:
       rplidar: { condition: service_started }
+      scan_filter: { condition: service_started }
       rosbot:  { condition: service_started }
     volumes:
       - ./config/nav2_${CONTROLLER:-rpp}_params.yaml:/params.yaml
@@ -111,25 +112,30 @@ services:
       navigation:
         condition: service_healthy
 
-  # --- Filtro de láser para no "verse a sí mismo" (opcional recomendado) ---
+  # Filtro de /scan → /scan_filtered
   scan_filter:
     image: ros:humble-ros-base
-    network_mode: host
-    restart: unless-stopped
-    command: >
-      bash -lc "
-        apt-get update -qq &&
-        apt-get install -y ros-humble-laser-filters &&
-        source /opt/ros/humble/setup.bash &&
-        ros2 run laser_filters scan_to_scan_filter_chain
-          --ros-args
-          -p scan_topic:=/scan
-          -p output_topic:=/scan_filtered
-          -p filter_config:=/config/scan_filters.yaml
-      "
+    depends_on: [ "rplidar" ]
+    network_mode: service:rosbot
     volumes:
-      - ./config/scan_filters.yaml:/config/scan_filters.yaml:ro
-    depends_on:
-      rplidar:
-        condition: service_started
+      - ./config:/config:ro
+    command: >
+      bash -lc "source /opt/ros/humble/setup.bash &&
+                ros2 run laser_filters scan_to_scan_filter_chain
+                --ros-args -p output:=scan_filtered
+                --params-file /config/laser_filters.yaml"
+    restart: unless-stopped
+
+  twist_mux:
+    image: ros:humble-ros-base
+    depends_on: [ "navigation" ]
+    network_mode: service:rosbot
+    volumes:
+      - ./config:/config:ro
+    command: >
+      bash -lc "source /opt/ros/humble/setup.bash &&
+                ros2 run twist_mux twist_mux
+                --ros-args --params-file /config/twist_mux.yaml
+                -r cmd_vel_out:=/cmd_vel_unstamped"
+    restart: unless-stopped
 

--- a/config/laser_filters.yaml
+++ b/config/laser_filters.yaml
@@ -1,0 +1,22 @@
+# Filtro de láser para no “verse a sí mismo”
+scan_to_scan_filter_chain:
+  ros__parameters:
+    scan_filter_chain:
+      - name: range_clip
+        type: laser_filters/LaserScanRangeFilter
+        params:
+          use_message_range_limits: false
+          lower_threshold: 0.18
+          upper_threshold: 8.0
+          lower_replacement_value: 8.0
+          upper_replacement_value: 8.0
+      - name: footprint_box
+        type: laser_filters/LaserScanBoxFilter
+        params:
+          box_frame: base_link
+          min_x: -0.22
+          max_x:  0.22
+          min_y: -0.20
+          max_y:  0.20
+          min_z: -0.10
+          max_z:  0.40

--- a/config/nav2_dwb_params.yaml
+++ b/config/nav2_dwb_params.yaml
@@ -1,3 +1,4 @@
+# === NAV2 – parámetros saneados para arranque fiable ===
 ---
 amcl:
   ros__parameters:
@@ -14,7 +15,7 @@ amcl:
     always_reset_initial_pose: true
 
     tf_broadcast: true
-    transform_tolerance: 1.0
+    transform_tolerance: 0.50
 
     alpha1: 0.2
     alpha2: 0.2
@@ -35,7 +36,7 @@ amcl:
     laser_max_range: 12.0
     laser_min_range: 0.2
     laser_model_type: likelihood_field
-    max_beams: 60
+    laser_max_beams: 40
     max_particles: 500
     min_particles: 200
 
@@ -223,19 +224,16 @@ local_costmap:
       width: 2
       height: 2
       resolution: 0.04
-      robot_radius: 0.20
+      footprint: [[-0.18, -0.16], [0.18, -0.16], [0.18, 0.16], [-0.18, 0.16]]
+      footprint_padding: 0.01
       plugins: [obstacle_layer, inflation_layer]
-      static_layer:
-        plugin: nav2_costmap_2d::StaticLayer
-        enabled: true
-        map_subscribe_transient_local: true
       obstacle_layer:
         plugin: nav2_costmap_2d::ObstacleLayer
         enabled: true
         observation_sources: scan
         scan:
-          topic: scan
-          max_obstacle_height: 2.0
+          topic: /scan_filtered
+          max_obstacle_height: 0.30
           clearing: true
           marking: true
           data_type: LaserScan
@@ -243,10 +241,11 @@ local_costmap:
           raytrace_min_range: 0.0
           obstacle_max_range: 2.5
           obstacle_min_range: 0.0
+          inf_is_valid: true
       inflation_layer:
         plugin: nav2_costmap_2d::InflationLayer
-        cost_scaling_factor: 3.0
-        inflation_radius: 0.55
+        cost_scaling_factor: 2.0
+        inflation_radius: 0.25
 
       always_send_full_costmap: true
 
@@ -258,31 +257,19 @@ global_costmap:
       global_frame: map
       robot_base_frame: base_link
       use_sim_time: false
-      robot_radius: 0.16
       resolution: 0.05
       track_unknown_space: true
-      plugins: [static_layer, obstacle_layer, inflation_layer]
+      footprint: [[-0.18, -0.16], [0.18, -0.16], [0.18, 0.16], [-0.18, 0.16]]
+      footprint_padding: 0.01
+      # *** MUY IMPORTANTE: sin obstáculo de láser en global ***
+      plugins: [static_layer, inflation_layer]
       static_layer:
         plugin: nav2_costmap_2d::StaticLayer
         map_subscribe_transient_local: true
-      obstacle_layer:
-        plugin: nav2_costmap_2d::ObstacleLayer
-        enabled: true
-        observation_sources: scan
-        scan:
-          topic: scan_filtered
-          max_obstacle_height: 2.0
-          clearing: true
-          marking: true
-          data_type: LaserScan
-          raytrace_max_range: 3.0
-          raytrace_min_range: 0.0
-          obstacle_max_range: 2.5
-          obstacle_min_range: 0.0
       inflation_layer:
         plugin: nav2_costmap_2d::InflationLayer
-        cost_scaling_factor: 3.0
-        inflation_radius: 0.55
+        cost_scaling_factor: 2.0
+        inflation_radius: 0.25
       always_send_full_costmap: true
 
 map_server:
@@ -306,7 +293,7 @@ planner_server:
     planner_plugins: [GridBased]
     GridBased:
       plugin: nav2_smac_planner/SmacPlanner2D
-      tolerance: 0.125 # tolerance for planning if unable to reach exact pose, in meters
+      tolerance: 0.15 # tolerance for planning if unable to reach exact pose, in meters
       downsample_costmap: false # whether or not to downsample the map
       downsampling_factor: 1 # multiplier for the resolution of the costmap layer (e.g. 2 on a 5cm costmap would be 10cm)
       allow_unknown: true # allow traveling in unknown space

--- a/config/nav2_dwb_webots_params.yaml
+++ b/config/nav2_dwb_webots_params.yaml
@@ -1,3 +1,4 @@
+# === NAV2 – parámetros saneados para arranque fiable ===
 ---
 amcl:
   ros__parameters:
@@ -14,7 +15,7 @@ amcl:
     always_reset_initial_pose: true
 
     tf_broadcast: true
-    transform_tolerance: 1.0
+    transform_tolerance: 0.50
 
     alpha1: 0.2
     alpha2: 0.2
@@ -35,7 +36,7 @@ amcl:
     laser_max_range: 12.0
     laser_min_range: 0.2
     laser_model_type: likelihood_field
-    max_beams: 60
+    laser_max_beams: 40
     max_particles: 500
     min_particles: 200
 
@@ -223,19 +224,16 @@ local_costmap:
       width: 2
       height: 2
       resolution: 0.04
-      robot_radius: 0.16
-      plugins: [static_layer, obstacle_layer, inflation_layer]
-      static_layer:
-        plugin: nav2_costmap_2d::StaticLayer
-        enabled: true
-        map_subscribe_transient_local: true
+      footprint: [[-0.18, -0.16], [0.18, -0.16], [0.18, 0.16], [-0.18, 0.16]]
+      footprint_padding: 0.01
+      plugins: [obstacle_layer, inflation_layer]
       obstacle_layer:
         plugin: nav2_costmap_2d::ObstacleLayer
         enabled: true
         observation_sources: scan
         scan:
-          topic: scan_filtered
-          max_obstacle_height: 2.0
+          topic: /scan_filtered
+          max_obstacle_height: 0.30
           clearing: true
           marking: true
           data_type: LaserScan
@@ -243,10 +241,11 @@ local_costmap:
           raytrace_min_range: 0.0
           obstacle_max_range: 2.5
           obstacle_min_range: 0.0
+          inf_is_valid: true
       inflation_layer:
         plugin: nav2_costmap_2d::InflationLayer
-        cost_scaling_factor: 3.0
-        inflation_radius: 0.55
+        cost_scaling_factor: 2.0
+        inflation_radius: 0.25
 
       always_send_full_costmap: true
 
@@ -258,31 +257,19 @@ global_costmap:
       global_frame: map
       robot_base_frame: base_link
       use_sim_time: false
-      robot_radius: 0.16
       resolution: 0.05
       track_unknown_space: true
-      plugins: [static_layer, obstacle_layer, inflation_layer]
+      footprint: [[-0.18, -0.16], [0.18, -0.16], [0.18, 0.16], [-0.18, 0.16]]
+      footprint_padding: 0.01
+      # *** MUY IMPORTANTE: sin obstáculo de láser en global ***
+      plugins: [static_layer, inflation_layer]
       static_layer:
         plugin: nav2_costmap_2d::StaticLayer
         map_subscribe_transient_local: true
-      obstacle_layer:
-        plugin: nav2_costmap_2d::ObstacleLayer
-        enabled: true
-        observation_sources: scan
-        scan:
-          topic: scan_filtered
-          max_obstacle_height: 2.0
-          clearing: true
-          marking: true
-          data_type: LaserScan
-          raytrace_max_range: 3.0
-          raytrace_min_range: 0.0
-          obstacle_max_range: 2.5
-          obstacle_min_range: 0.0
       inflation_layer:
         plugin: nav2_costmap_2d::InflationLayer
-        cost_scaling_factor: 3.0
-        inflation_radius: 0.55
+        cost_scaling_factor: 2.0
+        inflation_radius: 0.25
       always_send_full_costmap: true
 
 map_server:
@@ -306,7 +293,7 @@ planner_server:
     planner_plugins: [GridBased]
     GridBased:
       plugin: nav2_smac_planner/SmacPlanner2D
-      tolerance: 0.125 # tolerance for planning if unable to reach exact pose, in meters
+      tolerance: 0.15 # tolerance for planning if unable to reach exact pose, in meters
       downsample_costmap: false # whether or not to downsample the map
       downsampling_factor: 1 # multiplier for the resolution of the costmap layer (e.g. 2 on a 5cm costmap would be 10cm)
       allow_unknown: true # allow traveling in unknown space

--- a/config/nav2_mppi_params.yaml
+++ b/config/nav2_mppi_params.yaml
@@ -1,3 +1,4 @@
+# === NAV2 – parámetros saneados para arranque fiable ===
 ---
 amcl:
   ros__parameters:
@@ -14,7 +15,7 @@ amcl:
     always_reset_initial_pose: true
 
     tf_broadcast: true
-    transform_tolerance: 1.0
+    transform_tolerance: 0.50
 
     alpha1: 0.2
     alpha2: 0.2
@@ -35,7 +36,7 @@ amcl:
     laser_max_range: 12.0
     laser_min_range: 0.2
     laser_model_type: likelihood_field
-    max_beams: 60
+    laser_max_beams: 40
     max_particles: 500
     min_particles: 200
 
@@ -240,19 +241,16 @@ local_costmap:
       width: 4
       height: 4
       resolution: 0.04
-      footprint: '[[0.165, 0.145], [0.165, -0.145], [-0.165, -0.145], [-0.165, 0.145]]'
-      plugins: [static_layer, obstacle_layer, inflation_layer]
-      static_layer:
-        plugin: nav2_costmap_2d::StaticLayer
-        enabled: true
-        map_subscribe_transient_local: true
+      footprint: [[-0.18, -0.16], [0.18, -0.16], [0.18, 0.16], [-0.18, 0.16]]
+      footprint_padding: 0.01
+      plugins: [obstacle_layer, inflation_layer]
       obstacle_layer:
         plugin: nav2_costmap_2d::ObstacleLayer
         enabled: true
         observation_sources: scan
         scan:
-          topic: scan_filtered
-          max_obstacle_height: 2.0
+          topic: /scan_filtered
+          max_obstacle_height: 0.30
           clearing: true
           marking: true
           data_type: LaserScan
@@ -260,11 +258,12 @@ local_costmap:
           raytrace_min_range: 0.0
           obstacle_max_range: 2.5
           obstacle_min_range: 0.0
+          inf_is_valid: true
       inflation_layer:
         plugin: nav2_costmap_2d::InflationLayer
         enabled: true
-        cost_scaling_factor: 3.0
-        inflation_radius: 0.55
+        cost_scaling_factor: 2.0
+        inflation_radius: 0.25
 
       always_send_full_costmap: true
 
@@ -283,32 +282,20 @@ global_costmap:
       global_frame: map
       robot_base_frame: base_link
       use_sim_time: false
-      footprint: '[[0.165, 0.145], [0.165, -0.145], [-0.165, -0.145], [-0.165, 0.145]]'
+      footprint: [[-0.18, -0.16], [0.18, -0.16], [0.18, 0.16], [-0.18, 0.16]]
+      footprint_padding: 0.01
       resolution: 0.05
       track_unknown_space: true
-      plugins: [static_layer, obstacle_layer, inflation_layer]
+      # *** MUY IMPORTANTE: sin obstáculo de láser en global ***
+      plugins: [static_layer, inflation_layer]
       static_layer:
         plugin: nav2_costmap_2d::StaticLayer
         enabled: true
         map_subscribe_transient_local: true
-      obstacle_layer:
-        plugin: nav2_costmap_2d::ObstacleLayer
-        enabled: true
-        observation_sources: scan
-        scan:
-          topic: scan_filtered
-          max_obstacle_height: 2.0
-          clearing: true
-          marking: true
-          data_type: LaserScan
-          raytrace_max_range: 3.0
-          raytrace_min_range: 0.0
-          obstacle_max_range: 2.5
-          obstacle_min_range: 0.0
       inflation_layer:
         plugin: nav2_costmap_2d::InflationLayer
-        cost_scaling_factor: 3.0
-        inflation_radius: 0.55
+        cost_scaling_factor: 2.0
+        inflation_radius: 0.25
       always_send_full_costmap: true
   global_costmap_client:
     ros__parameters:
@@ -338,7 +325,7 @@ planner_server:
     planner_plugins: [GridBased]
     GridBased:
       plugin: nav2_smac_planner/SmacPlanner2D
-      tolerance: 0.125 # tolerance for planning if unable to reach exact pose, in meters
+      tolerance: 0.15 # tolerance for planning if unable to reach exact pose, in meters
       downsample_costmap: false # whether or not to downsample the map
       downsampling_factor: 1 # multiplier for the resolution of the costmap layer (e.g. 2 on a 5cm costmap would be 10cm)
       allow_unknown: true # allow traveling in unknown space

--- a/config/nav2_mppi_webots_params.yaml
+++ b/config/nav2_mppi_webots_params.yaml
@@ -1,3 +1,4 @@
+# === NAV2 – parámetros saneados para arranque fiable ===
 ---
 amcl:
   ros__parameters:
@@ -14,7 +15,7 @@ amcl:
     always_reset_initial_pose: true
 
     tf_broadcast: true
-    transform_tolerance: 1.0
+    transform_tolerance: 0.50
 
     alpha1: 0.2
     alpha2: 0.2
@@ -35,7 +36,7 @@ amcl:
     laser_max_range: 12.0
     laser_min_range: 0.2
     laser_model_type: likelihood_field
-    max_beams: 60
+    laser_max_beams: 40
     max_particles: 500
     min_particles: 200
 
@@ -241,19 +242,16 @@ local_costmap:
       width: 4
       height: 4
       resolution: 0.04
-      footprint: '[[0.165, 0.145], [0.165, -0.145], [-0.165, -0.145], [-0.165, 0.145]]'
-      plugins: [static_layer, obstacle_layer, inflation_layer]
-      static_layer:
-        plugin: nav2_costmap_2d::StaticLayer
-        enabled: true
-        map_subscribe_transient_local: true
+      footprint: [[-0.18, -0.16], [0.18, -0.16], [0.18, 0.16], [-0.18, 0.16]]
+      footprint_padding: 0.01
+      plugins: [obstacle_layer, inflation_layer]
       obstacle_layer:
         plugin: nav2_costmap_2d::ObstacleLayer
         enabled: true
         observation_sources: scan
         scan:
-          topic: scan_filtered
-          max_obstacle_height: 2.0
+          topic: /scan_filtered
+          max_obstacle_height: 0.30
           clearing: true
           marking: true
           data_type: LaserScan
@@ -261,11 +259,12 @@ local_costmap:
           raytrace_min_range: 0.0
           obstacle_max_range: 2.5
           obstacle_min_range: 0.0
+          inf_is_valid: true
       inflation_layer:
         plugin: nav2_costmap_2d::InflationLayer
         enabled: true
-        cost_scaling_factor: 3.0
-        inflation_radius: 0.55
+        cost_scaling_factor: 2.0
+        inflation_radius: 0.25
 
       always_send_full_costmap: true
 
@@ -284,32 +283,20 @@ global_costmap:
       global_frame: map
       robot_base_frame: base_link
       use_sim_time: false
-      footprint: '[[0.165, 0.145], [0.165, -0.145], [-0.165, -0.145], [-0.165, 0.145]]'
+      footprint: [[-0.18, -0.16], [0.18, -0.16], [0.18, 0.16], [-0.18, 0.16]]
+      footprint_padding: 0.01
       resolution: 0.05
       track_unknown_space: true
-      plugins: [static_layer, obstacle_layer, inflation_layer]
+      # *** MUY IMPORTANTE: sin obstáculo de láser en global ***
+      plugins: [static_layer, inflation_layer]
       static_layer:
         plugin: nav2_costmap_2d::StaticLayer
         enabled: true
         map_subscribe_transient_local: true
-      obstacle_layer:
-        plugin: nav2_costmap_2d::ObstacleLayer
-        enabled: true
-        observation_sources: scan
-        scan:
-          topic: scan_filtered
-          max_obstacle_height: 2.0
-          clearing: true
-          marking: true
-          data_type: LaserScan
-          raytrace_max_range: 3.0
-          raytrace_min_range: 0.0
-          obstacle_max_range: 2.5
-          obstacle_min_range: 0.0
       inflation_layer:
         plugin: nav2_costmap_2d::InflationLayer
-        cost_scaling_factor: 3.0
-        inflation_radius: 0.55
+        cost_scaling_factor: 2.0
+        inflation_radius: 0.25
       always_send_full_costmap: true
   global_costmap_client:
     ros__parameters:
@@ -339,7 +326,7 @@ planner_server:
     planner_plugins: [GridBased]
     GridBased:
       plugin: nav2_smac_planner/SmacPlanner2D
-      tolerance: 0.125 # tolerance for planning if unable to reach exact pose, in meters
+      tolerance: 0.15 # tolerance for planning if unable to reach exact pose, in meters
       downsample_costmap: false # whether or not to downsample the map
       downsampling_factor: 1 # multiplier for the resolution of the costmap layer (e.g. 2 on a 5cm costmap would be 10cm)
       allow_unknown: true # allow traveling in unknown space

--- a/config/nav2_rpp_params.yaml
+++ b/config/nav2_rpp_params.yaml
@@ -1,3 +1,4 @@
+# === NAV2 – parámetros saneados para arranque fiable ===
 ---
 amcl:
   ros__parameters:
@@ -14,7 +15,7 @@ amcl:
     always_reset_initial_pose: true
 
     tf_broadcast: true
-    transform_tolerance: 0.40
+    transform_tolerance: 0.50
 
     alpha1: 0.2
     alpha2: 0.2
@@ -133,29 +134,29 @@ controller_server:
     progress_checker_plugin: progress_checker
     progress_checker:
       plugin: nav2_controller::SimpleProgressChecker
-      required_movement_radius: 0.05
-      movement_time_allowance: 25.0
+      required_movement_radius: 0.03
+      movement_time_allowance: 30.0
 
     goal_checker_plugin: goal_checker
     goal_checker:
       plugin: nav2_controller::SimpleGoalChecker
       stateful: false
       xy_goal_tolerance: 0.25
-      yaw_goal_tolerance: 0.60
+      yaw_goal_tolerance: 0.80
 
     controller_plugins: [FollowPath]
     FollowPath:
       plugin: nav2_regulated_pure_pursuit_controller::RegulatedPurePursuitController
 
       # Velocity/acceleration limits also have to be adjusted in the velocity smoother
-      desired_linear_vel: 0.45
+      desired_linear_vel: 0.25
       transform_tolerance: 0.25
 
       # Adaptive lookahead gain
       use_velocity_scaled_lookahead_dist: true
-      min_lookahead_dist: 0.35
-      max_lookahead_dist: 0.90
-      lookahead_time: 1.2
+      min_lookahead_dist: 0.25
+      max_lookahead_dist: 0.80
+      lookahead_time: 1.0
 
       # Approach to goal
       min_approach_linear_velocity: 0.2
@@ -212,9 +213,9 @@ local_costmap:
       always_send_full_costmap: true
       rolling_window: true
 
-      footprint: '[[0.165, 0.145], [0.165, -0.145], [-0.165, -0.145], [-0.165, 0.145]]'
+      footprint: [[-0.18, -0.16], [0.18, -0.16], [0.18, 0.16], [-0.18, 0.16]]
       footprint_clearing_enabled: true
-      footprint_padding: -0.02
+      footprint_padding: 0.01
 
       plugins: [obstacle_layer, inflation_layer]
       obstacle_layer:
@@ -223,7 +224,7 @@ local_costmap:
         observation_sources: scan
         scan:
           topic: /scan_filtered
-          max_obstacle_height: 2.0
+          max_obstacle_height: 0.30
           clearing: true
           marking: true
           data_type: LaserScan
@@ -231,11 +232,12 @@ local_costmap:
           raytrace_min_range: 0.0
           obstacle_max_range: 2.5
           obstacle_min_range: 0.0
+          inf_is_valid: true
       inflation_layer:
         plugin: nav2_costmap_2d::InflationLayer
         enabled: true
-        inflation_radius: 0.30
-        cost_scaling_factor: 3.0
+        inflation_radius: 0.25
+        cost_scaling_factor: 2.0
 
   local_costmap_client:
     ros__parameters:
@@ -260,34 +262,21 @@ global_costmap:
       always_send_full_costmap: true
       track_unknown_space: true # if False, treats unknown space as free space, else as unknown space
 
-      footprint: '[[0.165, 0.145], [0.165, -0.145], [-0.165, -0.145], [-0.165, 0.145]]'
+      footprint: [[-0.18, -0.16], [0.18, -0.16], [0.18, 0.16], [-0.18, 0.16]]
       footprint_clearing_enabled: true
-      footprint_padding: -0.02
+      footprint_padding: 0.01
 
-      plugins: [static_layer, obstacle_layer, inflation_layer]
+      # *** MUY IMPORTANTE: sin obstáculo de láser en global ***
+      plugins: [static_layer, inflation_layer]
       static_layer:
         plugin: nav2_costmap_2d::StaticLayer
         enabled: true
         map_subscribe_transient_local: true
-      obstacle_layer:
-        plugin: nav2_costmap_2d::ObstacleLayer
-        enabled: true
-        observation_sources: scan
-        scan:
-          topic: /scan_filtered
-          max_obstacle_height: 2.0
-          clearing: true
-          marking: true
-          data_type: LaserScan
-          raytrace_max_range: 3.0
-          raytrace_min_range: 0.0
-          obstacle_max_range: 2.5
-          obstacle_min_range: 0.0
       inflation_layer:
         plugin: nav2_costmap_2d::InflationLayer
         enabled: true
-        inflation_radius: 0.30
-        cost_scaling_factor: 3.0
+        inflation_radius: 0.25
+        cost_scaling_factor: 2.0
 
   global_costmap_client:
     ros__parameters:
@@ -317,7 +306,7 @@ planner_server:
     planner_plugins: [GridBased]
     GridBased:
       plugin: nav2_smac_planner/SmacPlanner2D
-      tolerance: 0.125 # tolerance for planning if unable to reach exact pose, in meters
+      tolerance: 0.15 # tolerance for planning if unable to reach exact pose, in meters
       downsample_costmap: false # whether or not to downsample the map
       downsampling_factor: 1 # multiplier for the resolution of the costmap layer (e.g. 2 on a 5cm costmap would be 10cm)
       allow_unknown: true # allow traveling in unknown space

--- a/config/nav2_rpp_webots_params.yaml
+++ b/config/nav2_rpp_webots_params.yaml
@@ -1,3 +1,4 @@
+# === NAV2 – parámetros saneados para arranque fiable ===
 ---
 amcl:
   ros__parameters:
@@ -14,7 +15,7 @@ amcl:
     always_reset_initial_pose: true
 
     tf_broadcast: true
-    transform_tolerance: 1.0
+    transform_tolerance: 0.50
 
     alpha1: 0.2
     alpha2: 0.2
@@ -35,7 +36,7 @@ amcl:
     laser_max_range: 12.0
     laser_min_range: 0.2
     laser_model_type: likelihood_field
-    max_beams: 60
+    laser_max_beams: 40
     max_particles: 500
     min_particles: 200
 
@@ -210,20 +211,17 @@ local_costmap:
       always_send_full_costmap: true
       rolling_window: true
 
-      footprint: '[[0.165, 0.145], [0.165, -0.145], [-0.165, -0.145], [-0.165, 0.145]]'
+      footprint: [[-0.18, -0.16], [0.18, -0.16], [0.18, 0.16], [-0.18, 0.16]]
+      footprint_padding: 0.01
 
-      plugins: [static_layer, obstacle_layer, inflation_layer]
-      static_layer:
-        plugin: nav2_costmap_2d::StaticLayer
-        enabled: true
-        map_subscribe_transient_local: true
+      plugins: [obstacle_layer, inflation_layer]
       obstacle_layer:
         plugin: nav2_costmap_2d::ObstacleLayer
         enabled: true
         observation_sources: scan
         scan:
-          topic: scan_filtered
-          max_obstacle_height: 2.0
+          topic: /scan_filtered
+          max_obstacle_height: 0.30
           clearing: true
           marking: true
           data_type: LaserScan
@@ -231,11 +229,12 @@ local_costmap:
           raytrace_min_range: 0.0
           obstacle_max_range: 2.5
           obstacle_min_range: 0.0
+          inf_is_valid: true
       inflation_layer:
         plugin: nav2_costmap_2d::InflationLayer
         enabled: true
-        cost_scaling_factor: 3.0
-        inflation_radius: 0.55
+        cost_scaling_factor: 2.0
+        inflation_radius: 0.25
 
   local_costmap_client:
     ros__parameters:
@@ -260,32 +259,20 @@ global_costmap:
       always_send_full_costmap: true
       track_unknown_space: true # if False, treats unknown space as free space, else as unknown space
 
-      footprint: '[[0.165, 0.145], [0.165, -0.145], [-0.165, -0.145], [-0.165, 0.145]]'
+      footprint: [[-0.18, -0.16], [0.18, -0.16], [0.18, 0.16], [-0.18, 0.16]]
+      footprint_padding: 0.01
 
-      plugins: [static_layer, obstacle_layer, inflation_layer]
+      # *** MUY IMPORTANTE: sin obstáculo de láser en global ***
+      plugins: [static_layer, inflation_layer]
       static_layer:
         plugin: nav2_costmap_2d::StaticLayer
         enabled: true
         map_subscribe_transient_local: true
-      obstacle_layer:
-        plugin: nav2_costmap_2d::ObstacleLayer
-        enabled: true
-        observation_sources: scan
-        scan:
-          topic: scan_filtered
-          max_obstacle_height: 2.0
-          clearing: true
-          marking: true
-          data_type: LaserScan
-          raytrace_max_range: 3.0
-          raytrace_min_range: 0.0
-          obstacle_max_range: 2.5
-          obstacle_min_range: 0.0
       inflation_layer:
         plugin: nav2_costmap_2d::InflationLayer
         enabled: true
-        cost_scaling_factor: 3.0
-        inflation_radius: 0.55
+        cost_scaling_factor: 2.0
+        inflation_radius: 0.25
 
   global_costmap_client:
     ros__parameters:
@@ -315,7 +302,7 @@ planner_server:
     planner_plugins: [GridBased]
     GridBased:
       plugin: nav2_smac_planner/SmacPlanner2D
-      tolerance: 0.125 # tolerance for planning if unable to reach exact pose, in meters
+      tolerance: 0.15 # tolerance for planning if unable to reach exact pose, in meters
       downsample_costmap: false # whether or not to downsample the map
       downsampling_factor: 1 # multiplier for the resolution of the costmap layer (e.g. 2 on a 5cm costmap would be 10cm)
       allow_unknown: true # allow traveling in unknown space

--- a/config/twist_mux.yaml
+++ b/config/twist_mux.yaml
@@ -1,0 +1,7 @@
+# MUX para teleop + Nav2 → /cmd_vel_unstamped del base controller
+twist_mux:
+  ros__parameters:
+    topics:
+      - {name: nav2,   topic: /cmd_vel,           timeout: 0.5,  priority: 50}
+      - {name: teleop, topic: /teleop/cmd_vel,    timeout: 0.5,  priority: 100}
+    locks: []

--- a/scripts/path_player.py
+++ b/scripts/path_player.py
@@ -67,6 +67,7 @@ class Player(Node):
             Empty, "/global_costmap/clear_entirely_global_costmap"
         )
         self.cmd_pub = self.create_publisher(Twist, "/cmd_vel", 1)
+        self._amcl_ready = False
 
         # AMCL para medir progreso por intento
         self._amcl_last = None  # (x, y)
@@ -99,6 +100,9 @@ class Player(Node):
         yaw = 2.0 * atan2(float(q.z), float(q.w))
         self._amcl_last = (float(p.x), float(p.y))
         self._amcl_last_yaw = float(yaw)
+        cov_yaw = msg.pose.covariance[35]
+        if cov_yaw > 0.0 and cov_yaw < (math.radians(15) ** 2):
+            self._amcl_ready = True
 
     def _progress_since_attempt(self) -> float:
         if self._amcl_last is None or self._amcl_attempt_start is None:
@@ -214,6 +218,11 @@ class Player(Node):
                 self.initpose_mode,
                 self.init_bump if self.initpose_mode == "ahead" else 0.0,
             )
+        t0 = time.time()
+        while not self._amcl_ready and time.time() - t0 < 8.0:
+            rclpy.spin_once(self, timeout_sec=0.1)
+        if not self._amcl_ready:
+            self.get_logger().warn("AMCL no listo tras 8s; continúo igualmente")
         self._clear_costmaps()
         time.sleep(0.2)
         # 2) Marca inicio de intento para medir progreso


### PR DESCRIPTION
## Summary
- align all Nav2 parameter sets so global costmaps only stack the static and inflation layers with a consistent footprint and softer inflation tuning while local maps consume /scan_filtered
- add a reusable laser scan filter configuration, wire the filter service into the compose file, and introduce a twist_mux service so teleop and Nav2 both feed the base controller
- make the route player wait for a stable AMCL covariance before clearing costmaps and sending the first goal

## Testing
- python3 -m compileall scripts/path_player.py

------
https://chatgpt.com/codex/tasks/task_e_68cc0333b4648323955d5f9a71b8b31f