### PR TITLE
Update start-route recipe without docker inspect

### DIFF
--- a/justfile
+++ b/justfile
@@ -181,19 +181,19 @@ start-route ruta="mi_ruta":
     # 1) Levanta sólo compose.yaml (sin el override ⇒ no arranca teleop)
     @SLAM=False MAP=${MAP:-r1} docker compose -f compose.yaml up -d
 
-    # 2) Espera a Nav2 (healthy si existe; si no, que exponga acciones)
+    # 2) Espera a Nav2 (si hay healthcheck: (healthy); si no, que exponga acciones)
     @echo "⌛  Esperando a Nav2..."
     @bash -c '\
-      CID=$(docker compose -f compose.yaml ps -q navigation); \
+      # intenta 40 veces con 2s de espera (≈80 s)
       for i in {1..40}; do \
-        HC=$(docker inspect --format="{{.State.Health.Status}}" "$$CID" 2>/dev/null || echo none); \
-        if [ "$$HC" = "healthy" ]; then exit 0; fi; \
-        if [ "$$HC" = "none" ]; then \
-          docker compose -f compose.yaml exec -T navigation bash -lc \
-            "source /opt/ros/humble/setup.bash; ros2 action list | grep -q /navigate_through_poses" && exit 0; \
-        fi; \
+        # (a) Si el servicio tiene healthcheck, úsalo:
+        if docker compose -f compose.yaml ps navigation | grep -q "(healthy)"; then exit 0; fi; \
+        # (b) Si no hay healthcheck, valida que haya servidor de acciones en Nav2:
+        docker compose -f compose.yaml exec -T navigation bash -lc \
+          "source /opt/ros/humble/setup.bash; ros2 action list | grep -q /navigate_through_poses" && exit 0; \
         sleep 2; \
-      done; echo "⛔  navigation no healthy / no action server"; exit 1'
+      done; \
+      echo "⛔  navigation no healthy / no action server"; exit 1'
 
     # 3) Lanza el reproductor de waypoints dentro de path_tools
     @just play-path {{ruta}}


### PR DESCRIPTION
## Summary
- replace the Nav2 wait loop in the `start-route` recipe to avoid using `docker inspect`
- rely on `docker compose ps` health output or the action server check instead of the container health format string

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d270859b6c832388d00cda45ebf0de