### PR TITLE
Update start-route automation and compose services

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -51,21 +51,15 @@ services:
     environment:
       - ROS_DOMAIN_ID=0
       - MAP=${MAP:-r1}
-      - RCL_LOG_LEVEL=INFO
     volumes:
       - ./config/nav2_${CONTROLLER:-rpp}_params.yaml:/params.yaml
       - ./maps:/maps
     command: >
-      bash -lc "source /opt/ros/humble/setup.bash &&
-                ros2 launch /husarion_utils/bringup_launch.py
-                  slam:=${SLAM:-True}
-                  params_file:=/params.yaml
-                  map:=/maps/${MAP:-r1}.yaml
-                  use_sim_time:=False
-                --ros-args
-                --log-level planner_server:=info
-                --log-level global_costmap.global_costmap:=info
-                --log-level local_costmap.local_costmap:=info"
+      ros2 launch /husarion_utils/bringup_launch.py
+        slam:=${SLAM:-True}
+        params_file:=/params.yaml
+        map:=/maps/${MAP:-r1}.yaml
+        use_sim_time:=False
     healthcheck:
       test: ["CMD-SHELL",
              "bash -lc 'source /opt/ros/humble/setup.bash && \\
@@ -140,7 +134,9 @@ services:
     volumes:
       - ./config:/config:ro
     command: >
-      bash -lc "source /opt/ros/humble/setup.bash &&
+      bash -lc "apt-get update -qq &&
+                apt-get install -y -q ros-humble-laser-filters &&
+                source /opt/ros/humble/setup.bash &&
                 ros2 run laser_filters scan_to_scan_filter_chain
                 --ros-args -p output:=scan_filtered
                 --params-file /config/laser_filters.yaml"
@@ -162,7 +158,9 @@ services:
     volumes:
       - ./config:/config:ro
     command: >
-      bash -lc "source /opt/ros/humble/setup.bash &&
+      bash -lc "apt-get update -qq &&
+                apt-get install -y -q ros-humble-twist-mux &&
+                source /opt/ros/humble/setup.bash &&
                 ros2 run twist_mux twist_mux
                 --ros-args --params-file /config/twist_mux.yaml
                 -r cmd_vel_out:=/cmd_vel_unstamped"

--- a/justfile
+++ b/justfile
@@ -1,4 +1,6 @@
 set dotenv-load
+# Fuerza bash y aborta en el primer error
+set shell := ["bash", "-eu", "-o", "pipefail", "-c"]
 
 [private]
 default:
@@ -179,24 +181,36 @@ play-path name:
 # ────────────────────────────────────────────────────────────────
 start-route ruta="mi_ruta":
     # 1) Levanta sólo compose.yaml (sin el override ⇒ no arranca teleop)
-    @SLAM=False MAP=${MAP:-r1} docker compose -f compose.yaml up -d
+    SLAM=False MAP=${MAP:-r1} docker compose -f compose.yaml up -d
 
-    # 2) Espera a Nav2 (si hay healthcheck: (healthy); si no, que exponga acciones)
-    @echo "⌛  Esperando a Nav2..."
-    @bash -c '\
-      # intenta 40 veces con 2s de espera (≈80 s)
-      for i in {1..40}; do \
-        # (a) Si el servicio tiene healthcheck, úsalo:
-        if docker compose -f compose.yaml ps navigation | grep -q "(healthy)"; then exit 0; fi; \
-        # (b) Si no hay healthcheck, valida que haya servidor de acciones en Nav2:
-        docker compose -f compose.yaml exec -T navigation bash -lc \
-          "source /opt/ros/humble/setup.bash; ros2 action list | grep -q /navigate_through_poses" && exit 0; \
-        sleep 2; \
-      done; \
-      echo "⛔  navigation no healthy / no action server"; exit 1'
+    # 2) Espera a Nav2:
+    #    - Si hay healthcheck, espera a "(healthy)"
+    #    - Si no lo hay, valida que /navigate_through_poses esté publicado
+    echo "⌛  Esperando a Nav2..."
+    for i in {1..40}; do
+      if docker compose -f compose.yaml ps navigation | grep -q "(healthy)"; then
+        break
+      fi
+      if docker compose -f compose.yaml exec -T navigation bash -lc \
+        "source /opt/ros/humble/setup.bash; ros2 action list | grep -q /navigate_through_poses"
+      then
+        break
+      fi
+      sleep 2
+    done
+
+    # Comprobación final: ¿está healthy o con acciones expuestas?
+    if ! docker compose -f compose.yaml ps navigation | grep -q "(healthy)"; then
+      if ! docker compose -f compose.yaml exec -T navigation bash -lc \
+        "source /opt/ros/humble/setup.bash; ros2 action list | grep -q /navigate_through_poses"
+      then
+        echo "⛔  navigation no healthy / no action server"
+        exit 1
+      fi
+    fi
 
     # 3) Lanza el reproductor de waypoints dentro de path_tools
-    @just play-path {{ruta}}
+    just play-path {{ruta}}
 
 # ────────────────────────────────────────────────────────────────
 #  ruta1  →  atajo sin parámetros. Equivale a:


### PR DESCRIPTION
## Summary
- force all just recipes to run under bash with strict error handling and replace the start-route helper to wait for Nav2 before replaying paths
- simplify the navigation command while keeping its healthcheck and ensure scan_filter and twist_mux install the ROS packages they need at runtime

## Testing
- just --list *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d273843fc8832399a605a71a2f031d