### PR TITLE
Ensure map saver node is available for SLAM

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -166,3 +166,16 @@ services:
                 -r cmd_vel_out:=/cmd_vel_unstamped"
     restart: unless-stopped
 
+  map_saver:
+    image: husarion/navigation2:humble-1.1.12-20240123
+    network_mode: host
+    restart: unless-stopped
+    environment:
+      - ROS_DOMAIN_ID=0
+    depends_on:
+      navigation:
+        condition: service_started
+    command: >
+      bash -lc "source /opt/ros/humble/setup.bash &&
+                ros2 run nav2_map_server map_saver_server"
+

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -36,13 +36,6 @@ services:
                  cmd_vel:=/cmd_vel"
 
   ###############################################################
-  # 3) Navigation 2 (activo: genera /map)
-  ###############################################################
-  navigation:
-    volumes:
-      - ./maps:/home/husarion/rosbotxl/maps
-
-  ###############################################################
   # 4) explore_lite dormido (evita exploración autónoma)
   ###############################################################
   explore_lite:

--- a/justfile
+++ b/justfile
@@ -180,20 +180,18 @@ play-path name:
 #     Uso:  just start-route mi_ruta        # (omite la extensión .yaml)
 # ────────────────────────────────────────────────────────────────
 start-route ruta="mi_ruta":
-    # 1) Levanta sólo compose.yaml (sin el override ⇒ no arranca teleop)
+    # 1) Levanta solo compose.yaml (sin override ⇒ no arranca teleop)
     SLAM=False MAP=${MAP:-r1} docker compose -f compose.yaml up -d
 
-    # 2) Espera a Nav2 (healthy o acciones expuestas), sin llaves dobles ni indent raro
-    echo "⌛  Esperando a Nav2..."
-    bash -lc 'set -euo pipefail; \
-      for i in {1..40}; do \
-        docker compose -f compose.yaml ps navigation | grep -q "(healthy)" && exit 0; \
-        docker compose -f compose.yaml exec -T navigation bash -lc "source /opt/ros/humble/setup.bash; ros2 action list | grep -q /navigate_through_poses" && exit 0; \
-        sleep 2; \
-      done; \
-      echo "⛔  navigation no healthy / no action server"; exit 1'
+    # 2) Espera simple a Nav2 (sin healthcheck, sin escapes raros)
+    @echo "⌛  Esperando a Nav2 (30 s)…"
+    sleep 30
 
-    # 3) Lanza el reproductor de waypoints dentro de path_tools
+    # 3) Comprobación mínima: ¿está el servidor de acciones?
+    @echo "🔎  Acciones disponibles:"
+    docker compose exec -T navigation bash -lc 'source /opt/ros/humble/setup.bash && ros2 action list'
+
+    # 4) Lanza el reproductor de waypoints dentro de path_tools
     just play-path {{ruta}}
 
 # ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- remove the navigation service override from the override compose file so the base volume mounts remain intact
- add a dedicated map_saver service so the lifecycle manager can activate SLAM and publish /map
- simplify the `start-route` recipe to use a fixed wait and action list check instead of depending on the health check

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d28273a6648323816ae1e98892c3c8