### PR TITLE
Cleanup compose services and add navigation logging

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -53,6 +53,8 @@ services:
     environment:
       ROS_DOMAIN_ID: "0"
       MAP: "${MAP:-r1}"
+      RCL_LOG_LEVEL: "info"
+      RCUTILS_CONSOLE_OUTPUT_FORMAT: "[{severity}] {name}: {message}"
     volumes:
       - ./config/nav2_${CONTROLLER:-rpp}_params.yaml:/params.yaml
       - ./maps:/maps
@@ -171,35 +173,4 @@ services:
                 --ros-args --params-file /config/twist_mux.yaml
                 -r cmd_vel_out:=/cmd_vel_unstamped"
     restart: unless-stopped
-
-  map_saver:
-    image: husarion/navigation2:humble-1.1.12-20240123
-    network_mode: host
-    restart: unless-stopped
-    environment:
-      ROS_DOMAIN_ID: "0"
-    depends_on:
-      navigation:
-        condition: service_started
-    command: >
-      bash -lc "source /opt/ros/humble/setup.bash &&
-                ros2 run nav2_map_server map_saver_server"
-
-  ros_diag:
-    image: ros:humble-ros-base
-    network_mode: host
-    restart: unless-stopped
-    environment:
-      ROS_DOMAIN_ID: "0"
-    volumes:
-      - ./scripts/ros_diag.sh:/ros_diag.sh:ro
-    command: >
-      bash -lc "source /opt/ros/humble/setup.bash &&
-                chmod +x /ros_diag.sh &&
-                /ros_diag.sh"
-    depends_on:
-      rplidar:
-        condition: service_started
-      scan_filter:
-        condition: service_started
 

--- a/justfile
+++ b/justfile
@@ -180,19 +180,31 @@ play-path name:
 #     Uso:  just start-route mi_ruta
 # ────────────────────────────────────────────────────────────────
 start-route ruta="mi_ruta":
-    # 1) Levanta solo compose.yaml (sin el override ⇒ no arranca teleop)
+    # 1) Levanta sólo compose.yaml (sin el override ⇒ no arranca teleop)
     SLAM=False MAP=${MAP:-r1} docker compose -f compose.yaml up -d
 
-    # 2) Espera simple a Nav2 (40 s)
-    @echo "⌛  Esperando a Nav2 (40 s)…"
-    sleep 40
+    # 2) Lanza el reproductor de waypoints dentro de path_tools
+    @echo "▶︎ Ejecutando player: {{ruta}}"
+    -@docker compose exec -it path_tools bash -lc \
+      "source /opt/ros/humble/setup.bash && \
+       python3 /scripts/path_player.py \
+         --file /routes/{{ruta}}.yaml \
+         --align-to-current true \
+         --initpose first \
+         --init-bump 0.20 \
+         --nudge false \
+         --allow-skip true \
+         --min-progress-to-skip 0.08"
 
-    # 3) Lista de acciones (diagnóstico)
-    @echo "🔎  Acciones expuestas por navigation:"
-    docker compose exec -T navigation bash -lc 'source /opt/ros/humble/setup.bash && ros2 action list || true'
-
-    # 4) Lanza el reproductor de waypoints dentro de path_tools
-    just play-path {{ruta}}
+    # 3) Si falló el player, imprime diagnóstico mínimo de navigation
+    @status=$$?; \
+     if [ "$$status" -ne 0 ]; then \
+       echo ""; echo "⛔ Player falló (código $$status). Logs de navigation ↓↓↓"; \
+       docker compose -f compose.yaml logs --no-color --tail=200 navigation || true; \
+       echo ""; echo "🔎 Acciones disponibles ↓↓↓"; \
+       docker compose -f compose.yaml exec -T navigation bash -lc 'source /opt/ros/humble/setup.bash; ros2 action list || true'; \
+       exit $$status; \
+     fi
 
 # ────────────────────────────────────────────────────────────────
 #  ruta1  →  atajo sin parámetros. Equivale a:


### PR DESCRIPTION
## Summary
- remove the map_saver and ros_diag services from compose.yaml to restore the earlier stack layout
- add RCL logging environment variables to the navigation service
- update the start-route recipe to execute the path player directly and capture diagnostics when it fails

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d2b453a88c83239d30fc5f0b3ebd14