### PR TITLE
Revert Ctrl-C shutdown handling in path recorder

### DIFF
--- a/justfile
+++ b/justfile
@@ -158,10 +158,11 @@ teleop:
 
 # Grabar un recorrido con teleoperación activa
 record-path name:
-    @echo "Grabando recorrido {{name}} — pulsa Ctrl-C para terminar"
-    docker compose exec -it path_tools bash -lc \
-      "source /opt/ros/humble/setup.bash && \
-       python3 /scripts/path_recorder.py --output /routes/{{name}}.yaml"
+    @echo "Grabando recorrido {{name}} –\u00a0pulsa Ctrl-C para terminar"
+    docker exec -it $(docker compose ps -q path_tools) \
+        bash -c "source /opt/ros/humble/setup.bash && \
+                 python3 /scripts/path_recorder.py \
+                 --output /routes/{{name}}.yaml"
 
 # Reproducir un recorrido con Nav2 (fluido, alineado a AMCL, sin nudge)
 play-path name:

--- a/scripts/path_recorder.py
+++ b/scripts/path_recorder.py
@@ -8,6 +8,7 @@ Se detiene con Ctrl‑C.
 """
 
 import math
+import signal
 import sys
 
 import rclpy
@@ -83,11 +84,20 @@ if __name__ == "__main__":
     out_file = parse_output_arg()
     rclpy.init()
     recorder = Recorder(out_file)
+
+    def _handle_sigint(*_args):
+        recorder.shutdown()
+        if rclpy.ok():
+            rclpy.shutdown()
+        sys.exit(0)
+
+    signal.signal(signal.SIGINT, _handle_sigint)
     try:
         rclpy.spin(recorder)
-    except KeyboardInterrupt:
+    except SystemExit:
         pass
     finally:
         recorder.shutdown()
         recorder.destroy_node()
-        rclpy.shutdown()
+        if rclpy.ok():
+            rclpy.shutdown()


### PR DESCRIPTION
## Summary
- restore the `record-path` recipe to invoke the recorder container the way it worked before the Ctrl-C shutdown change
- reinstate the signal handler in `path_recorder.py` so Ctrl-C exits via the previous shutdown flow

## Testing
- python3 -m compileall scripts/path_recorder.py

------
https://chatgpt.com/codex/tasks/task_e_68d2bb66fb2c83238ae5e7593f25af55