### PR TITLE
Make RPLIDAR serial device configurable

### DIFF
--- a/.env
+++ b/.env
@@ -8,6 +8,9 @@
 # - 115200 - for RPlidar A2M8 (red circle around the sensor)
 LIDAR_BAUDRATE=1000000
 
+# Select LIDAR serial device (use /dev/serial/by-id/... for stable mapping)
+RPLIDAR_BYID=/dev/ttyUSB1
+
 # Select wheel type:
 # - True - mecanum wheels
 # - False - regular

--- a/README.md
+++ b/README.md
@@ -84,9 +84,12 @@ To ensure proper user configuration, review the content of the `.env` file and s
 - **`SAVE_MAP_PERIOD`** - period of time for autosave map (set `0` to disable),
 - **`CONTROLLER`** - choose the navigation controller type,
 
-The RPLIDAR sensor is configured in `compose.yaml` to use `/dev/ttyUSB1`
-with a baud rate of `1000000`. Adjust these settings in the Compose file
-if your hardware requires a different configuration.
+The RPLIDAR sensor is configured in `compose.yaml` to use the
+`/dev/rplidar` alias, which by default maps to `/dev/ttyUSB1`. Update the
+`RPLIDAR_BYID` value in `.env` (for example with the
+`/dev/serial/by-id/...` path) if your hardware appears on a different
+port. The baud rate is controlled via the `LIDAR_BAUDRATE` setting in
+`.env`.
 
 ### 🤖 Step 4: Running Navigation & Mapping
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -24,16 +24,17 @@ services:
     image: husarion/rplidar:humble-1.0.1-20240104
     restart: unless-stopped
 
-    # Usa el puerto que acabamos de comprobar
+    # Usa un enlace estable al puerto serie del LIDAR
     devices:
-      - /dev/ttyUSB1:/dev/ttyUSB1
+      - ${RPLIDAR_BYID:-/dev/ttyUSB1}:/dev/rplidar
 
     command: >
       ros2 launch /husarion_utils/rplidar.launch.py
-        serial_port:=/dev/ttyUSB1
-        serial_baudrate:=1000000
+        serial_port:=/dev/rplidar
+        serial_baudrate:=${LIDAR_BAUDRATE:-1000000}
 
-    environment: [ROS_DOMAIN_ID=0]
+    environment:
+      - ROS_DOMAIN_ID=0
     healthcheck:
       test: ["CMD-SHELL",
              "bash -c 'source /opt/ros/humble/setup.bash && ros2 topic list | grep -q ^/scan$'"]


### PR DESCRIPTION
## Summary
- map the RPLIDAR device inside the container via the `/dev/rplidar` alias so it can be configured with the `RPLIDAR_BYID` variable and respect the `LIDAR_BAUDRATE` setting
- add a default `RPLIDAR_BYID` entry to `.env` for easy customization of the host serial device
- document the new configuration flow in the README

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d3f7532ae0832391ea8a9122550e95