### PR TITLE
Fix navigation command comment and mount Nav2 params file

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -53,13 +53,15 @@ services:
     #    no podrá modificar tu mapa en disco.
     volumes:
       - ./maps:/maps:ro
+      - ./config/nav2_${CONTROLLER:-rpp}_params.yaml:/params.yaml:ro
 
     # 2) lanza bringup en modo navegación *sin* SLAM y
     #    cargando el mapa que ya tienes grabado.
+    # nombre EXACTO del mapa:
     command: >
       ros2 launch rosbot_xl_bringup navigation.launch.py
         slam:=False
-        map:=/maps/almacen1.yaml           # ← nombre EXACTO del mapa
+        map:=/maps/almacen1.yaml
         params_file:=/params.yaml
         use_sim_time:=False
 


### PR DESCRIPTION
## Summary
- add nav2 params file bind mount for the navigation container
- move map name comment outside the command block to satisfy docker compose requirements

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d403ef8a8883239f73b70eaa5dfe21