### PR TITLE
Configure environment with stable RPLIDAR mapping

### DIFF
--- a/.env
+++ b/.env
@@ -8,8 +8,9 @@
 # - 115200 - for RPlidar A2M8 (red circle around the sensor)
 LIDAR_BAUDRATE=1000000
 
-# Select LIDAR serial device (use /dev/serial/by-id/... for stable mapping)
-RPLIDAR_BYID=/dev/ttyUSB1
+# Stable RPLIDAR device mapping
+RPLIDAR_BYID=/dev/serial/by-id/usb-Silicon_Labs_CP2102N_USB_to_UART_Bridge_Controller_e6b5eba20a77ed119ad9f0fafdf7b791-if00-port0
+RPLIDAR_PORT=/dev/rplidar
 
 # Select wheel type:
 # - True - mecanum wheels
@@ -24,6 +25,9 @@ MECANUM=False
 # - True - with mapping
 # - False - without mapping
 SLAM=True
+
+# Mapa por defecto (usado por compose/navigation)
+MAP=r1
 
 # Period of time for autosave map. Work only when SLAM=True (set 0 to disable)
 SAVE_MAP_PERIOD=15


### PR DESCRIPTION
## Summary
- update `.env` with the stable RPLIDAR by-id path and exposed symlink
- define the default navigation map used by compose navigation setups

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d40f02c6188323869f2db70fda2b0b