### PR TITLE
Restore stable lidar configuration and map defaults

### DIFF
--- a/.env
+++ b/.env
@@ -8,6 +8,10 @@
 # - 115200 - for RPlidar A2M8 (red circle around the sensor)
 LIDAR_BAUDRATE=1000000
 
+# Stable RPLIDAR device mapping
+RPLIDAR_BYID=/dev/serial/by-id/usb-Silicon_Labs_CP2102N_USB_to_UART_Bridge_Controller_e6b5eba20a77ed119ad9f0fafdf7b791-if00-port0
+RPLIDAR_PORT=/dev/rplidar
+
 # Select wheel type:
 # - True - mecanum wheels
 # - False - regular
@@ -21,6 +25,9 @@ MECANUM=False
 # - True - with mapping
 # - False - without mapping
 SLAM=True
+
+# Default map used by navigation
+MAP=r1
 
 # Period of time for autosave map. Work only when SLAM=True (set 0 to disable)
 SAVE_MAP_PERIOD=15

--- a/compose.yaml
+++ b/compose.yaml
@@ -23,41 +23,37 @@ services:
   rplidar:
     image: husarion/rplidar:humble-1.0.1-20240104
     restart: unless-stopped
-
-    # Usa el puerto que acabamos de comprobar
     devices:
-      - /dev/ttyUSB1:/dev/ttyUSB1
-
+      - ${RPLIDAR_BYID:-/dev/ttyUSB0}:/dev/rplidar
     command: >
       ros2 launch /husarion_utils/rplidar.launch.py
-        serial_port:=/dev/ttyUSB1
-        serial_baudrate:=1000000
-
-    environment: [ROS_DOMAIN_ID=0]
+        serial_port:=${RPLIDAR_PORT:-/dev/rplidar}
+        serial_baudrate:=${LIDAR_BAUDRATE:-1000000}
+    environment: [ ROS_DOMAIN_ID=0 ]
     healthcheck:
       test: ["CMD-SHELL",
              "bash -c 'source /opt/ros/humble/setup.bash && ros2 topic list | grep -q ^/scan$'"]
       interval: 30s
       timeout: 5s
-      start_period: 40s
+      start_period: 90s
       retries: 10
 
   navigation:
     image: husarion/navigation2:humble-1.1.12-20240123
     restart: unless-stopped
     depends_on:
-      rplidar:
-        condition: service_healthy
-      rosbot:
-        condition: service_healthy
+      rplidar: { condition: service_started }
+      rosbot:  { condition: service_started }
     volumes:
       - ./config/nav2_${CONTROLLER:-rpp}_params.yaml:/params.yaml
       - ./maps:/maps
+    environment:
+      - MAP=${MAP:-r1}
     command: >
       ros2 launch /husarion_utils/bringup_launch.py
         slam:=${SLAM:-True}
         params_file:=/params.yaml
-        map:=/maps/almacen_nuevo.yaml
+        map:=/maps/${MAP:-r1}.yaml
         use_sim_time:=False
 
   path_tools:
@@ -106,6 +102,7 @@ services:
       dockerfile: Dockerfile.explore_lite
     network_mode: host
     restart: unless-stopped
+    profiles: ["explore"]
     volumes:
       - ./config/explore_params.yaml:/opt/explore_ws/explore_params.yaml:ro
     depends_on:

--- a/scripts/path_recorder.py
+++ b/scripts/path_recorder.py
@@ -18,7 +18,7 @@ def yaw_from_quaternion(q):
     cosy_cosp = 1.0 - 2.0 * (y * y + z * z)
     return math.atan2(siny_cosp, cosy_cosp)
 
-DIST_THRESHOLD = 0.10  # metros entre muestras
+DIST_THRESHOLD = 0.80  # metros entre muestras
 
 
 class Recorder(Node):


### PR DESCRIPTION
## Summary
- restore stable RPLIDAR device mapping variables and default map settings in .env
- update docker compose to use parametrized lidar devices, map selection, and gate explore_lite behind the explore profile
- revert path recorder sampling distance to the stable threshold while keeping the SIGINT handler

## Testing
- ⚠️ `pre-commit run --all-files` *(fails: command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d41d17f7d88323bca41eb1a2c6e02c