### PR TITLE
Ensure path recorder handles Ctrl-C cleanly

### DIFF
--- a/justfile
+++ b/justfile
@@ -156,11 +156,10 @@ teleop:
 
 # Grabar un recorrido con teleoperación activa
 record-path name:
-    @echo "Grabando recorrido {{name}} –\u00a0pulsa Ctrl-C para terminar"
-    docker exec -it $(docker compose ps -q path_tools) \
-        bash -c "source /opt/ros/humble/setup.bash && \
-                 python3 /scripts/path_recorder.py \
-                 --output /routes/{{name}}.yaml"
+    @echo "Grabando recorrido {{name}} — pulsa Ctrl-C para terminar"
+    docker compose exec -it path_tools bash -lc \
+      "source /opt/ros/humble/setup.bash && \
+       python3 /scripts/path_recorder.py --output /routes/{{name}}.yaml"
 
 # Reproducir un recorrido con Nav2 (esquiva de obstáculos)
 play-path name:

--- a/scripts/path_recorder.py
+++ b/scripts/path_recorder.py
@@ -5,7 +5,7 @@ Uso:
   ros2 run path_tools path_recorder.py --output /routes/nombre.yaml
 Se detiene con Ctrl‑C.
 """
-import sys, math, yaml, signal, rclpy
+import sys, math, yaml, rclpy
 from rclpy.node import Node
 from geometry_msgs.msg import PoseWithCovarianceStamped
 
@@ -68,9 +68,14 @@ def main():
     out_file = sys.argv[sys.argv.index("--output") + 1]
     rclpy.init()
     node = Recorder(out_file)
-    # Ctrl‑C clean
-    signal.signal(signal.SIGINT, lambda *_: node.shutdown() or sys.exit(0))
-    rclpy.spin(node)
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.shutdown()
+        node.destroy_node()
+        rclpy.shutdown()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- ensure the path recorder always shuts down and saves routes when interrupted with Ctrl-C
- run the record-path helper via `docker compose exec` with `bash -lc` so Ctrl-C reaches the recorder process

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d41ed47d2483239e7917db168578c0