### PR TITLE
Add laser scan filter container and use /scan_filtered topic

### DIFF
--- a/Dockerfile.scan_filter
+++ b/Dockerfile.scan_filter
@@ -1,0 +1,5 @@
+FROM ros:humble-ros-base
+RUN apt-get update && apt-get install -y ros-humble-laser-filters && rm -rf /var/lib/apt/lists/*
+ENV ROS_DOMAIN_ID=0
+CMD ["ros2","run","laser_filters","scan_to_scan_filter_chain",
+     "--ros-args","--params-file","/config/laser_filters.yaml"]

--- a/compose.yaml
+++ b/compose.yaml
@@ -38,6 +38,18 @@ services:
       start_period: 90s
       retries: 10
 
+  scan_filter:
+    build:
+      context: .
+      dockerfile: Dockerfile.scan_filter
+    network_mode: host
+    restart: unless-stopped
+    environment: [ ROS_DOMAIN_ID=0 ]
+    volumes:
+      - ./config/laser_filters.yaml:/config/laser_filters.yaml:ro
+    depends_on:
+      - rplidar
+
   navigation:
     image: husarion/navigation2:humble-1.1.12-20240123
     restart: unless-stopped

--- a/config/laser_filters.yaml
+++ b/config/laser_filters.yaml
@@ -1,0 +1,38 @@
+scan_to_scan_filter_chain:
+  ros__parameters:
+    # Publica en /scan_filtered por defecto (el nodo usa el mismo frame que /scan)
+    output_queue_size: 1
+
+    # Cadena de filtros (puedes ajustar umbrales si tu chasis está más cerca/lejos)
+    scan_filter_chain:
+      - name: range
+        type: laser_filters/LaserScanRangeFilter
+        params:
+          lower_threshold: 0.18      # ignora retornos < 18 cm (ajusta 0.18–0.25)
+          upper_threshold: 20.0
+          lower_replacement_value: inf
+          upper_replacement_value: inf
+
+      - name: shadows
+        type: laser_filters/ScanShadowsFilter
+        params:
+          min_angle: 10.0
+          max_angle: 170.0
+          neighbors: 1
+          window: 1
+
+      # Opcional: enmascara un sector frontal/trasero si el soporte del sensor entra en el haz
+      # - name: sector
+      #   type: laser_filters/LaserScanAngularBoundsFilter
+      #   params:
+      #     lower_angle: -0.35      # ~ -20 grados
+      #     upper_angle:  0.35      # ~ +20 grados
+
+      # Opcional: quita puntos dentro de una caja centrada en el sensor (si aún te “ves” a ti mismo)
+      # - name: box
+      #   type: laser_filters/LaserScanBoxFilter
+      #   params:
+      #     box_frame: laser
+      #     min_x: -0.20; max_x: 0.20
+      #     min_y: -0.20; max_y: 0.20
+      #     min_z: -0.10; max_z: 0.40

--- a/config/nav2_dwb_params.yaml
+++ b/config/nav2_dwb_params.yaml
@@ -6,7 +6,7 @@ amcl:
     global_frame_id: map
     odom_frame_id: odom
     base_frame_id: base_link
-    scan_topic: scan_filtered
+    scan_topic: /scan_filtered
 
     robot_model_type: nav2_amcl::DifferentialMotionModel
 
@@ -230,19 +230,19 @@ local_costmap:
         enabled: true
         map_subscribe_transient_local: true
       obstacle_layer:
-        plugin: nav2_costmap_2d::ObstacleLayer
+        plugin: "nav2_costmap_2d::ObstacleLayer"
         enabled: true
+        footprint_clearing_enabled: true
         observation_sources: scan
         scan:
-          topic: scan
-          max_obstacle_height: 2.0
-          clearing: true
+          topic: /scan_filtered
+          data_type: "LaserScan"
           marking: true
-          data_type: LaserScan
-          raytrace_max_range: 3.0
-          raytrace_min_range: 0.0
-          obstacle_max_range: 2.5
-          obstacle_min_range: 0.0
+          clearing: true
+          inf_is_valid: true
+          obstacle_range: 6.0
+          raytrace_range: 8.0
+          max_obstacle_height: 2.0
       inflation_layer:
         plugin: nav2_costmap_2d::InflationLayer
         cost_scaling_factor: 3.0
@@ -266,19 +266,19 @@ global_costmap:
         plugin: nav2_costmap_2d::StaticLayer
         map_subscribe_transient_local: true
       obstacle_layer:
-        plugin: nav2_costmap_2d::ObstacleLayer
+        plugin: "nav2_costmap_2d::ObstacleLayer"
         enabled: true
+        footprint_clearing_enabled: true
         observation_sources: scan
         scan:
-          topic: scan_filtered
-          max_obstacle_height: 2.0
-          clearing: true
+          topic: /scan_filtered
+          data_type: "LaserScan"
           marking: true
-          data_type: LaserScan
-          raytrace_max_range: 3.0
-          raytrace_min_range: 0.0
-          obstacle_max_range: 2.5
-          obstacle_min_range: 0.0
+          clearing: true
+          inf_is_valid: true
+          obstacle_range: 6.0
+          raytrace_range: 8.0
+          max_obstacle_height: 2.0
       inflation_layer:
         plugin: nav2_costmap_2d::InflationLayer
         cost_scaling_factor: 3.0
@@ -337,7 +337,7 @@ slam_toolbox:
     odom_frame: odom
     map_frame: map
     base_frame: base_link
-    scan_topic: scan_filtered
+    scan_topic: /scan_filtered
     use_map_saver: true
     mode: mapping #localization
 

--- a/config/nav2_dwb_webots_params.yaml
+++ b/config/nav2_dwb_webots_params.yaml
@@ -6,7 +6,7 @@ amcl:
     global_frame_id: map
     odom_frame_id: odom
     base_frame_id: base_link
-    scan_topic: scan_filtered
+    scan_topic: /scan_filtered
 
     robot_model_type: nav2_amcl::DifferentialMotionModel
 
@@ -230,19 +230,19 @@ local_costmap:
         enabled: true
         map_subscribe_transient_local: true
       obstacle_layer:
-        plugin: nav2_costmap_2d::ObstacleLayer
+        plugin: "nav2_costmap_2d::ObstacleLayer"
         enabled: true
+        footprint_clearing_enabled: true
         observation_sources: scan
         scan:
-          topic: scan_filtered
-          max_obstacle_height: 2.0
-          clearing: true
+          topic: /scan_filtered
+          data_type: "LaserScan"
           marking: true
-          data_type: LaserScan
-          raytrace_max_range: 3.0
-          raytrace_min_range: 0.0
-          obstacle_max_range: 2.5
-          obstacle_min_range: 0.0
+          clearing: true
+          inf_is_valid: true
+          obstacle_range: 6.0
+          raytrace_range: 8.0
+          max_obstacle_height: 2.0
       inflation_layer:
         plugin: nav2_costmap_2d::InflationLayer
         cost_scaling_factor: 3.0
@@ -266,19 +266,19 @@ global_costmap:
         plugin: nav2_costmap_2d::StaticLayer
         map_subscribe_transient_local: true
       obstacle_layer:
-        plugin: nav2_costmap_2d::ObstacleLayer
+        plugin: "nav2_costmap_2d::ObstacleLayer"
         enabled: true
+        footprint_clearing_enabled: true
         observation_sources: scan
         scan:
-          topic: scan_filtered
-          max_obstacle_height: 2.0
-          clearing: true
+          topic: /scan_filtered
+          data_type: "LaserScan"
           marking: true
-          data_type: LaserScan
-          raytrace_max_range: 3.0
-          raytrace_min_range: 0.0
-          obstacle_max_range: 2.5
-          obstacle_min_range: 0.0
+          clearing: true
+          inf_is_valid: true
+          obstacle_range: 6.0
+          raytrace_range: 8.0
+          max_obstacle_height: 2.0
       inflation_layer:
         plugin: nav2_costmap_2d::InflationLayer
         cost_scaling_factor: 3.0
@@ -337,7 +337,7 @@ slam_toolbox:
     odom_frame: odom
     map_frame: map
     base_frame: base_link
-    scan_topic: scan_filtered
+    scan_topic: /scan_filtered
     use_map_saver: true
     mode: mapping #localization
 

--- a/config/nav2_mppi_params.yaml
+++ b/config/nav2_mppi_params.yaml
@@ -6,7 +6,7 @@ amcl:
     global_frame_id: map
     odom_frame_id: odom
     base_frame_id: base_link
-    scan_topic: scan_filtered
+    scan_topic: /scan_filtered
 
     robot_model_type: nav2_amcl::DifferentialMotionModel
 
@@ -247,19 +247,19 @@ local_costmap:
         enabled: true
         map_subscribe_transient_local: true
       obstacle_layer:
-        plugin: nav2_costmap_2d::ObstacleLayer
+        plugin: "nav2_costmap_2d::ObstacleLayer"
         enabled: true
+        footprint_clearing_enabled: true
         observation_sources: scan
         scan:
-          topic: scan_filtered
-          max_obstacle_height: 2.0
-          clearing: true
+          topic: /scan_filtered
+          data_type: "LaserScan"
           marking: true
-          data_type: LaserScan
-          raytrace_max_range: 3.0
-          raytrace_min_range: 0.0
-          obstacle_max_range: 2.5
-          obstacle_min_range: 0.0
+          clearing: true
+          inf_is_valid: true
+          obstacle_range: 6.0
+          raytrace_range: 8.0
+          max_obstacle_height: 2.0
       inflation_layer:
         plugin: nav2_costmap_2d::InflationLayer
         enabled: true
@@ -292,19 +292,19 @@ global_costmap:
         enabled: true
         map_subscribe_transient_local: true
       obstacle_layer:
-        plugin: nav2_costmap_2d::ObstacleLayer
+        plugin: "nav2_costmap_2d::ObstacleLayer"
         enabled: true
+        footprint_clearing_enabled: true
         observation_sources: scan
         scan:
-          topic: scan_filtered
-          max_obstacle_height: 2.0
-          clearing: true
+          topic: /scan_filtered
+          data_type: "LaserScan"
           marking: true
-          data_type: LaserScan
-          raytrace_max_range: 3.0
-          raytrace_min_range: 0.0
-          obstacle_max_range: 2.5
-          obstacle_min_range: 0.0
+          clearing: true
+          inf_is_valid: true
+          obstacle_range: 6.0
+          raytrace_range: 8.0
+          max_obstacle_height: 2.0
       inflation_layer:
         plugin: nav2_costmap_2d::InflationLayer
         cost_scaling_factor: 3.0
@@ -404,7 +404,7 @@ slam_toolbox:
     odom_frame: odom
     map_frame: map
     base_frame: base_link
-    scan_topic: scan_filtered
+    scan_topic: /scan_filtered
     use_map_saver: true
     mode: mapping #localization
 

--- a/config/nav2_mppi_webots_params.yaml
+++ b/config/nav2_mppi_webots_params.yaml
@@ -6,7 +6,7 @@ amcl:
     global_frame_id: map
     odom_frame_id: odom
     base_frame_id: base_link
-    scan_topic: scan_filtered
+    scan_topic: /scan_filtered
 
     robot_model_type: nav2_amcl::DifferentialMotionModel
 
@@ -248,19 +248,19 @@ local_costmap:
         enabled: true
         map_subscribe_transient_local: true
       obstacle_layer:
-        plugin: nav2_costmap_2d::ObstacleLayer
+        plugin: "nav2_costmap_2d::ObstacleLayer"
         enabled: true
+        footprint_clearing_enabled: true
         observation_sources: scan
         scan:
-          topic: scan_filtered
-          max_obstacle_height: 2.0
-          clearing: true
+          topic: /scan_filtered
+          data_type: "LaserScan"
           marking: true
-          data_type: LaserScan
-          raytrace_max_range: 3.0
-          raytrace_min_range: 0.0
-          obstacle_max_range: 2.5
-          obstacle_min_range: 0.0
+          clearing: true
+          inf_is_valid: true
+          obstacle_range: 6.0
+          raytrace_range: 8.0
+          max_obstacle_height: 2.0
       inflation_layer:
         plugin: nav2_costmap_2d::InflationLayer
         enabled: true
@@ -293,19 +293,19 @@ global_costmap:
         enabled: true
         map_subscribe_transient_local: true
       obstacle_layer:
-        plugin: nav2_costmap_2d::ObstacleLayer
+        plugin: "nav2_costmap_2d::ObstacleLayer"
         enabled: true
+        footprint_clearing_enabled: true
         observation_sources: scan
         scan:
-          topic: scan_filtered
-          max_obstacle_height: 2.0
-          clearing: true
+          topic: /scan_filtered
+          data_type: "LaserScan"
           marking: true
-          data_type: LaserScan
-          raytrace_max_range: 3.0
-          raytrace_min_range: 0.0
-          obstacle_max_range: 2.5
-          obstacle_min_range: 0.0
+          clearing: true
+          inf_is_valid: true
+          obstacle_range: 6.0
+          raytrace_range: 8.0
+          max_obstacle_height: 2.0
       inflation_layer:
         plugin: nav2_costmap_2d::InflationLayer
         cost_scaling_factor: 3.0
@@ -405,7 +405,7 @@ slam_toolbox:
     odom_frame: odom
     map_frame: map
     base_frame: base_link
-    scan_topic: scan_filtered
+    scan_topic: /scan_filtered
     use_map_saver: true
     mode: mapping #localization
 

--- a/config/nav2_rpp_params.yaml
+++ b/config/nav2_rpp_params.yaml
@@ -6,7 +6,7 @@ amcl:
     global_frame_id: map
     odom_frame_id: odom
     base_frame_id: base_link
-    scan_topic: scan_filtered
+    scan_topic: /scan_filtered
 
     robot_model_type: nav2_amcl::DifferentialMotionModel
 
@@ -218,19 +218,19 @@ local_costmap:
         enabled: true
         map_subscribe_transient_local: true
       obstacle_layer:
-        plugin: nav2_costmap_2d::ObstacleLayer
+        plugin: "nav2_costmap_2d::ObstacleLayer"
         enabled: true
+        footprint_clearing_enabled: true
         observation_sources: scan
         scan:
-          topic: scan_filtered
-          max_obstacle_height: 2.0
-          clearing: true
+          topic: /scan_filtered
+          data_type: "LaserScan"
           marking: true
-          data_type: LaserScan
-          raytrace_max_range: 3.0
-          raytrace_min_range: 0.0
-          obstacle_max_range: 2.5
-          obstacle_min_range: 0.0
+          clearing: true
+          inf_is_valid: true
+          obstacle_range: 6.0
+          raytrace_range: 8.0
+          max_obstacle_height: 2.0
       inflation_layer:
         plugin: nav2_costmap_2d::InflationLayer
         enabled: true
@@ -268,19 +268,19 @@ global_costmap:
         enabled: true
         map_subscribe_transient_local: true
       obstacle_layer:
-        plugin: nav2_costmap_2d::ObstacleLayer
+        plugin: "nav2_costmap_2d::ObstacleLayer"
         enabled: true
+        footprint_clearing_enabled: true
         observation_sources: scan
         scan:
-          topic: scan_filtered
-          max_obstacle_height: 2.0
-          clearing: true
+          topic: /scan_filtered
+          data_type: "LaserScan"
           marking: true
-          data_type: LaserScan
-          raytrace_max_range: 3.0
-          raytrace_min_range: 0.0
-          obstacle_max_range: 2.5
-          obstacle_min_range: 0.0
+          clearing: true
+          inf_is_valid: true
+          obstacle_range: 6.0
+          raytrace_range: 8.0
+          max_obstacle_height: 2.0
       inflation_layer:
         plugin: nav2_costmap_2d::InflationLayer
         enabled: true
@@ -349,7 +349,7 @@ slam_toolbox:
     odom_frame: odom
     map_frame: map
     base_frame: base_link
-    scan_topic: scan_filtered
+    scan_topic: /scan_filtered
     use_map_saver: true
     mode: mapping #localization
 

--- a/config/nav2_rpp_webots_params.yaml
+++ b/config/nav2_rpp_webots_params.yaml
@@ -6,7 +6,7 @@ amcl:
     global_frame_id: map
     odom_frame_id: odom
     base_frame_id: base_link
-    scan_topic: scan_filtered
+    scan_topic: /scan_filtered
 
     robot_model_type: nav2_amcl::DifferentialMotionModel
 
@@ -218,19 +218,19 @@ local_costmap:
         enabled: true
         map_subscribe_transient_local: true
       obstacle_layer:
-        plugin: nav2_costmap_2d::ObstacleLayer
+        plugin: "nav2_costmap_2d::ObstacleLayer"
         enabled: true
+        footprint_clearing_enabled: true
         observation_sources: scan
         scan:
-          topic: scan_filtered
-          max_obstacle_height: 2.0
-          clearing: true
+          topic: /scan_filtered
+          data_type: "LaserScan"
           marking: true
-          data_type: LaserScan
-          raytrace_max_range: 3.0
-          raytrace_min_range: 0.0
-          obstacle_max_range: 2.5
-          obstacle_min_range: 0.0
+          clearing: true
+          inf_is_valid: true
+          obstacle_range: 6.0
+          raytrace_range: 8.0
+          max_obstacle_height: 2.0
       inflation_layer:
         plugin: nav2_costmap_2d::InflationLayer
         enabled: true
@@ -268,19 +268,19 @@ global_costmap:
         enabled: true
         map_subscribe_transient_local: true
       obstacle_layer:
-        plugin: nav2_costmap_2d::ObstacleLayer
+        plugin: "nav2_costmap_2d::ObstacleLayer"
         enabled: true
+        footprint_clearing_enabled: true
         observation_sources: scan
         scan:
-          topic: scan_filtered
-          max_obstacle_height: 2.0
-          clearing: true
+          topic: /scan_filtered
+          data_type: "LaserScan"
           marking: true
-          data_type: LaserScan
-          raytrace_max_range: 3.0
-          raytrace_min_range: 0.0
-          obstacle_max_range: 2.5
-          obstacle_min_range: 0.0
+          clearing: true
+          inf_is_valid: true
+          obstacle_range: 6.0
+          raytrace_range: 8.0
+          max_obstacle_height: 2.0
       inflation_layer:
         plugin: nav2_costmap_2d::InflationLayer
         enabled: true
@@ -349,7 +349,7 @@ slam_toolbox:
     odom_frame: odom
     map_frame: map
     base_frame: base_link
-    scan_topic: scan_filtered
+    scan_topic: /scan_filtered
     use_map_saver: true
     mode: mapping #localization
 

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -68,7 +68,7 @@ services:
   # foxglove  se queda tal y como está en tu compose.yaml
 
 ###############################################################
-# 7) Static transform  (láser 20 cm detrás, 30 cm arriba)
+# 7) Static transform  (láser → óptica con rotación estándar)
 ###############################################################
   static_tf:
     image: husarion/rosbot-xl:humble-0.10.0-20240202
@@ -76,8 +76,8 @@ services:
     restart: unless-stopped
     environment: [ ROS_DOMAIN_ID=0 ]
     command: [ "ros2", "run", "tf2_ros", "static_transform_publisher",
-               "-0.20", "0.00", "0.30",        # x  y  z
-               "-1.5708", "0", "1.5708",       # roll  pitch  yaw
+               "0", "0", "0",              # x y z
+               "-1.5708", "0", "1.5708",   # roll pitch yaw (láser→optical)
                "laser", "oak_rgb_camera_optical_frame" ]
 
 ###############################################################


### PR DESCRIPTION
## Summary
- update the static laser-to-camera transform to use the standard optical rotation with zero translation
- add a laser scan filtering container, configuration, and compose service to publish /scan_filtered
- retarget Nav2 parameter sets (including Webots variants) to /scan_filtered and enable obstacle-layer footprint clearing and raytracing of inf ranges

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d42a3863b083238afc10ddb6500dce