### PR TITLE
Use single-line CMD in scan filter Dockerfile

### DIFF
--- a/Dockerfile.scan_filter
+++ b/Dockerfile.scan_filter
@@ -1,5 +1,4 @@
 FROM ros:humble-ros-base
 RUN apt-get update && apt-get install -y ros-humble-laser-filters && rm -rf /var/lib/apt/lists/*
 ENV ROS_DOMAIN_ID=0
-CMD ["ros2","run","laser_filters","scan_to_scan_filter_chain",
-     "--ros-args","--params-file","/config/laser_filters.yaml"]
+CMD ["ros2","run","laser_filters","scan_to_scan_filter_chain","--ros-args","--params-file","/config/laser_filters.yaml"]


### PR DESCRIPTION
## Summary
- update the scan filter Dockerfile to express the CMD instruction on a single line

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d42f66300c8323aa1c2c9fcf4492e2