### PR TITLE
Improve lidar filtering and Nav2 configuration

### DIFF
--- a/config/laser_filters.yaml
+++ b/config/laser_filters.yaml
@@ -1,38 +1,24 @@
 scan_to_scan_filter_chain:
   ros__parameters:
-    # Publica en /scan_filtered por defecto (el nodo usa el mismo frame que /scan)
     output_queue_size: 1
-
-    # Cadena de filtros (puedes ajustar umbrales si tu chasis está más cerca/lejos)
     scan_filter_chain:
-      - name: range
+      - name: range_near_clip
         type: laser_filters/LaserScanRangeFilter
         params:
-          lower_threshold: 0.18      # ignora retornos < 18 cm (ajusta 0.18–0.25)
-          upper_threshold: 20.0
-          lower_replacement_value: inf
-          upper_replacement_value: inf
+          lower_threshold: 0.30          # sube a 0.35 si aún te “ves”
+          upper_threshold: 12.0
+          lower_replacement_value: nan   # CLAVE: descarta cercano (no limpia)
+          upper_replacement_value: inf   # lejos normal
 
       - name: shadows
         type: laser_filters/ScanShadowsFilter
         params:
-          min_angle: 10.0
+          min_angle: 0.0
           max_angle: 170.0
-          neighbors: 1
-          window: 1
+          neighbors: 20
+          window: 0
 
-      # Opcional: enmascara un sector frontal/trasero si el soporte del sensor entra en el haz
-      # - name: sector
-      #   type: laser_filters/LaserScanAngularBoundsFilter
-      #   params:
-      #     lower_angle: -0.35      # ~ -20 grados
-      #     upper_angle:  0.35      # ~ +20 grados
-
-      # Opcional: quita puntos dentro de una caja centrada en el sensor (si aún te “ves” a ti mismo)
-      # - name: box
-      #   type: laser_filters/LaserScanBoxFilter
-      #   params:
-      #     box_frame: laser
-      #     min_x: -0.20; max_x: 0.20
-      #     min_y: -0.20; max_y: 0.20
-      #     min_z: -0.10; max_z: 0.40
+      - name: median
+        type: laser_filters/LaserScanMedianFilter
+        params:
+          window: 5

--- a/config/nav2_dwb_params.yaml
+++ b/config/nav2_dwb_params.yaml
@@ -14,7 +14,7 @@ amcl:
     always_reset_initial_pose: true
 
     tf_broadcast: true
-    transform_tolerance: 1.0
+    transform_tolerance: 0.30
 
     alpha1: 0.2
     alpha2: 0.2
@@ -32,8 +32,8 @@ amcl:
 
     lambda_short: 0.1
     laser_likelihood_max_dist: 2.0
-    laser_max_range: 12.0
-    laser_min_range: 0.2
+    laser_min_range: 0.30
+    laser_max_range: 8.0
     laser_model_type: likelihood_field
     max_beams: 60
     max_particles: 500
@@ -219,11 +219,13 @@ local_costmap:
       global_frame: odom
       robot_base_frame: base_link
       use_sim_time: false
+      transform_tolerance: 0.30
       rolling_window: true
       width: 2
       height: 2
       resolution: 0.04
-      robot_radius: 0.20
+      robot_radius: 0.18
+      footprint_padding: 0.005
       plugins: [obstacle_layer, inflation_layer]
       static_layer:
         plugin: nav2_costmap_2d::StaticLayer
@@ -240,13 +242,14 @@ local_costmap:
           marking: true
           clearing: true
           inf_is_valid: true
-          obstacle_range: 6.0
-          raytrace_range: 8.0
-          max_obstacle_height: 2.0
+          obstacle_range: 4.0
+          raytrace_range: 5.0
+          observation_persistence: 0.0
       inflation_layer:
         plugin: nav2_costmap_2d::InflationLayer
-        cost_scaling_factor: 3.0
-        inflation_radius: 0.55
+        enabled: true
+        inflation_radius: 0.05
+        cost_scaling_factor: 8.0
 
       always_send_full_costmap: true
 
@@ -258,7 +261,9 @@ global_costmap:
       global_frame: map
       robot_base_frame: base_link
       use_sim_time: false
-      robot_radius: 0.16
+      transform_tolerance: 0.30
+      robot_radius: 0.18
+      footprint_padding: 0.005
       resolution: 0.05
       track_unknown_space: true
       plugins: [static_layer, obstacle_layer, inflation_layer]
@@ -276,13 +281,14 @@ global_costmap:
           marking: true
           clearing: true
           inf_is_valid: true
-          obstacle_range: 6.0
-          raytrace_range: 8.0
-          max_obstacle_height: 2.0
+          obstacle_range: 4.0
+          raytrace_range: 5.0
+          observation_persistence: 0.0   # NO arrastre
       inflation_layer:
         plugin: nav2_costmap_2d::InflationLayer
-        cost_scaling_factor: 3.0
-        inflation_radius: 0.55
+        enabled: true
+        inflation_radius: 0.05
+        cost_scaling_factor: 8.0
       always_send_full_costmap: true
 
 map_server:

--- a/config/nav2_mppi_params.yaml
+++ b/config/nav2_mppi_params.yaml
@@ -14,7 +14,7 @@ amcl:
     always_reset_initial_pose: true
 
     tf_broadcast: true
-    transform_tolerance: 1.0
+    transform_tolerance: 0.30
 
     alpha1: 0.2
     alpha2: 0.2
@@ -32,8 +32,8 @@ amcl:
 
     lambda_short: 0.1
     laser_likelihood_max_dist: 2.0
-    laser_max_range: 12.0
-    laser_min_range: 0.2
+    laser_min_range: 0.30
+    laser_max_range: 8.0
     laser_model_type: likelihood_field
     max_beams: 60
     max_particles: 500
@@ -236,11 +236,11 @@ local_costmap:
       global_frame: odom
       robot_base_frame: base_link
       use_sim_time: false
+      transform_tolerance: 0.30
       rolling_window: true
       width: 4
       height: 4
       resolution: 0.04
-      footprint: '[[0.165, 0.145], [0.165, -0.145], [-0.165, -0.145], [-0.165, 0.145]]'
       plugins: [static_layer, obstacle_layer, inflation_layer]
       static_layer:
         plugin: nav2_costmap_2d::StaticLayer
@@ -257,14 +257,17 @@ local_costmap:
           marking: true
           clearing: true
           inf_is_valid: true
-          obstacle_range: 6.0
-          raytrace_range: 8.0
-          max_obstacle_height: 2.0
+          obstacle_range: 4.0
+          raytrace_range: 5.0
+          observation_persistence: 0.0
       inflation_layer:
         plugin: nav2_costmap_2d::InflationLayer
         enabled: true
-        cost_scaling_factor: 3.0
-        inflation_radius: 0.55
+        inflation_radius: 0.05
+        cost_scaling_factor: 8.0
+
+      robot_radius: 0.18
+      footprint_padding: 0.005
 
       always_send_full_costmap: true
 
@@ -283,7 +286,7 @@ global_costmap:
       global_frame: map
       robot_base_frame: base_link
       use_sim_time: false
-      footprint: '[[0.165, 0.145], [0.165, -0.145], [-0.165, -0.145], [-0.165, 0.145]]'
+      transform_tolerance: 0.30
       resolution: 0.05
       track_unknown_space: true
       plugins: [static_layer, obstacle_layer, inflation_layer]
@@ -302,13 +305,16 @@ global_costmap:
           marking: true
           clearing: true
           inf_is_valid: true
-          obstacle_range: 6.0
-          raytrace_range: 8.0
-          max_obstacle_height: 2.0
+          obstacle_range: 4.0
+          raytrace_range: 5.0
+          observation_persistence: 0.0   # NO arrastre
       inflation_layer:
         plugin: nav2_costmap_2d::InflationLayer
-        cost_scaling_factor: 3.0
-        inflation_radius: 0.55
+        enabled: true
+        inflation_radius: 0.05
+        cost_scaling_factor: 8.0
+      robot_radius: 0.18
+      footprint_padding: 0.005
       always_send_full_costmap: true
   global_costmap_client:
     ros__parameters:

--- a/config/nav2_rpp_params.yaml
+++ b/config/nav2_rpp_params.yaml
@@ -14,7 +14,7 @@ amcl:
     always_reset_initial_pose: true
 
     tf_broadcast: true
-    transform_tolerance: 1.0
+    transform_tolerance: 0.30
 
     alpha1: 0.2
     alpha2: 0.2
@@ -32,8 +32,8 @@ amcl:
 
     lambda_short: 0.1
     laser_likelihood_max_dist: 2.0
-    laser_max_range: 12.0
-    laser_min_range: 0.2
+    laser_min_range: 0.30
+    laser_max_range: 8.0
     laser_model_type: likelihood_field
     max_beams: 60
     max_particles: 500
@@ -196,6 +196,7 @@ local_costmap:
   local_costmap:
     ros__parameters:
       use_sim_time: false
+      transform_tolerance: 0.30
 
       global_frame: odom
       robot_base_frame: base_link
@@ -210,8 +211,6 @@ local_costmap:
       always_send_full_costmap: true
       rolling_window: true
 
-      footprint: '[[0.165, 0.145], [0.165, -0.145], [-0.165, -0.145], [-0.165, 0.145]]'
-
       plugins: [static_layer, obstacle_layer, inflation_layer]
       static_layer:
         plugin: nav2_costmap_2d::StaticLayer
@@ -228,14 +227,17 @@ local_costmap:
           marking: true
           clearing: true
           inf_is_valid: true
-          obstacle_range: 6.0
-          raytrace_range: 8.0
-          max_obstacle_height: 2.0
+          obstacle_range: 4.0
+          raytrace_range: 5.0
+          observation_persistence: 0.0
       inflation_layer:
         plugin: nav2_costmap_2d::InflationLayer
         enabled: true
-        cost_scaling_factor: 3.0
-        inflation_radius: 0.55
+        inflation_radius: 0.05
+        cost_scaling_factor: 8.0
+
+      robot_radius: 0.18
+      footprint_padding: 0.005
 
   local_costmap_client:
     ros__parameters:
@@ -248,6 +250,7 @@ global_costmap:
   global_costmap:
     ros__parameters:
       use_sim_time: false
+      transform_tolerance: 0.30
 
       global_frame: map
       robot_base_frame: base_link
@@ -259,8 +262,6 @@ global_costmap:
 
       always_send_full_costmap: true
       track_unknown_space: true # if False, treats unknown space as free space, else as unknown space
-
-      footprint: '[[0.165, 0.145], [0.165, -0.145], [-0.165, -0.145], [-0.165, 0.145]]'
 
       plugins: [static_layer, obstacle_layer, inflation_layer]
       static_layer:
@@ -278,14 +279,17 @@ global_costmap:
           marking: true
           clearing: true
           inf_is_valid: true
-          obstacle_range: 6.0
-          raytrace_range: 8.0
-          max_obstacle_height: 2.0
+          obstacle_range: 4.0
+          raytrace_range: 5.0
+          observation_persistence: 0.0   # NO arrastre
       inflation_layer:
         plugin: nav2_costmap_2d::InflationLayer
         enabled: true
-        cost_scaling_factor: 3.0
-        inflation_radius: 0.55
+        inflation_radius: 0.05
+        cost_scaling_factor: 8.0
+
+      robot_radius: 0.18
+      footprint_padding: 0.005
 
   global_costmap_client:
     ros__parameters:

--- a/justfile
+++ b/justfile
@@ -182,6 +182,11 @@ start-route ruta="mi_ruta":
         docker compose ps navigation | grep -q "(healthy)" && exit 0; \
         sleep 2; done; echo "⛔  navigation no healthy"; exit 1'
 
+    # 2b) Arranque limpio: borra posibles "manchas" residuales
+    @docker compose exec navigation bash -lc 'source /opt/ros/humble/setup.bash; \
+        ros2 service call /local_costmap/clear_entire_costmap nav2_msgs/srv/ClearEntireCostmap "{}"; \
+        ros2 service call /global_costmap/clear_entire_costmap nav2_msgs/srv/ClearEntireCostmap "{}"'
+
     # 3) Lanza el reproductor de waypoints dentro de path_tools
     @just play-path {{ruta}}
 

--- a/scripts/path_player.py
+++ b/scripts/path_player.py
@@ -47,6 +47,10 @@ class Player(Node):
     # --- Acción FollowWaypoints ------------------------------------
     def _send_goal(self):
         self.client.wait_for_server()
+        # Sella timestampts para evitar "mensajes viejos" en filtros/TF
+        now = self.get_clock().now().to_msg()
+        for ps in self.waypoints:
+            ps.header.stamp = now
         goal_msg = FollowWaypoints.Goal(poses=self.waypoints)
         self.get_logger().info("🚀  Enviando acción /follow_waypoints …")
         send_future = self.client.send_goal_async(goal_msg, feedback_callback=self._feedback)
@@ -75,8 +79,12 @@ def main():
         sys.exit(1)
     yaml_file = sys.argv[sys.argv.index("--file") + 1]
     rclpy.init()
-    Player(yaml_file)
-    rclpy.spin(Player)
+    node = Player(yaml_file)
+    try:
+        rclpy.spin(node)
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- replace the laser filter chain to drop near returns via NaNs and add shadow/median smoothing
- align AMCL and costmap settings across Nav2 configs for the 50 cm profile using the filtered scan
- stamp waypoint timestamps and clear costmaps automatically before running stored routes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d64e0fc6e08323aae63bf8c8f49cb6