### PR TITLE
Improve Nav2 filtering and costmap tuning

### DIFF
--- a/.env
+++ b/.env
@@ -36,7 +36,7 @@ SAVE_MAP_PERIOD=15
 # - dwb - DWB controller
 # - rpp - Regulated Pure Pursuit
 # - mppi - Model Predictive Path Integral
-CONTROLLER=mppi
+CONTROLLER=rpp
 
 # =======================================
 # Namespace / Husarnet config

--- a/config/laser_filters.yaml
+++ b/config/laser_filters.yaml
@@ -2,14 +2,29 @@ scan_to_scan_filter_chain:
   ros__parameters:
     output_queue_size: 1
     scan_filter_chain:
+      # Quita el cuerpo del robot en base_link:
+      - name: remove_robot_body
+        type: laser_filters/LaserScanBoxFilter
+        params:
+          box_frame: base_link
+          min_x: -0.23
+          max_x:  0.23
+          min_y: -0.20
+          max_y:  0.20
+          min_z: -1.0
+          max_z:  1.0
+          invert: false
+
+      # Ver hasta 0.20 m delante (personas cerca) sin "abanicos":
       - name: range_near_clip
         type: laser_filters/LaserScanRangeFilter
         params:
-          lower_threshold: 0.30          # sube a 0.35 si aún te “ves”
+          lower_threshold: 0.20
           upper_threshold: 12.0
-          lower_replacement_value: nan   # CLAVE: descarta cercano (no limpia)
-          upper_replacement_value: inf   # lejos normal
+          lower_replacement_value: nan
+          upper_replacement_value: inf
 
+      # Limpieza de cantos y speckles:
       - name: shadows
         type: laser_filters/ScanShadowsFilter
         params:
@@ -21,4 +36,4 @@ scan_to_scan_filter_chain:
       - name: median
         type: laser_filters/LaserScanMedianFilter
         params:
-          window: 5
+          window: 7

--- a/config/nav2_dwb_params.yaml
+++ b/config/nav2_dwb_params.yaml
@@ -214,8 +214,8 @@ controller_server:
 local_costmap:
   local_costmap:
     ros__parameters:
-      update_frequency: 3.0
-      publish_frequency: 2.0
+      update_frequency: 10.0
+      publish_frequency: 5.0
       global_frame: odom
       robot_base_frame: base_link
       use_sim_time: false
@@ -227,18 +227,14 @@ local_costmap:
       robot_radius: 0.18
       footprint_padding: 0.005
       plugins: [obstacle_layer, inflation_layer]
-      static_layer:
-        plugin: nav2_costmap_2d::StaticLayer
-        enabled: true
-        map_subscribe_transient_local: true
       obstacle_layer:
-        plugin: "nav2_costmap_2d::ObstacleLayer"
+        plugin: nav2_costmap_2d::ObstacleLayer
         enabled: true
         footprint_clearing_enabled: true
         observation_sources: scan
         scan:
           topic: /scan_filtered
-          data_type: "LaserScan"
+          data_type: LaserScan
           marking: true
           clearing: true
           inf_is_valid: true
@@ -248,7 +244,7 @@ local_costmap:
       inflation_layer:
         plugin: nav2_costmap_2d::InflationLayer
         enabled: true
-        inflation_radius: 0.05
+        inflation_radius: 0.07
         cost_scaling_factor: 8.0
 
       always_send_full_costmap: true
@@ -256,8 +252,8 @@ local_costmap:
 global_costmap:
   global_costmap:
     ros__parameters:
-      update_frequency: 1.0
-      publish_frequency: 1.0
+      update_frequency: 5.0
+      publish_frequency: 2.0
       global_frame: map
       robot_base_frame: base_link
       use_sim_time: false
@@ -271,13 +267,13 @@ global_costmap:
         plugin: nav2_costmap_2d::StaticLayer
         map_subscribe_transient_local: true
       obstacle_layer:
-        plugin: "nav2_costmap_2d::ObstacleLayer"
+        plugin: nav2_costmap_2d::ObstacleLayer
         enabled: true
         footprint_clearing_enabled: true
         observation_sources: scan
         scan:
           topic: /scan_filtered
-          data_type: "LaserScan"
+          data_type: LaserScan
           marking: true
           clearing: true
           inf_is_valid: true
@@ -287,7 +283,7 @@ global_costmap:
       inflation_layer:
         plugin: nav2_costmap_2d::InflationLayer
         enabled: true
-        inflation_radius: 0.05
+        inflation_radius: 0.07
         cost_scaling_factor: 8.0
       always_send_full_costmap: true
 

--- a/config/nav2_mppi_params.yaml
+++ b/config/nav2_mppi_params.yaml
@@ -118,12 +118,17 @@ bt_navigator_rclcpp_node:
 controller_server:
   ros__parameters:
     use_sim_time: false
-    controller_frequency: 5.0
+    controller_frequency: 20.0
     min_x_velocity_threshold: 0.01    # Measured
     min_y_velocity_threshold: 0.01    # Measured
     min_theta_velocity_threshold: 0.1 # Measured
     progress_checker_plugin: progress_checker
     goal_checker_plugin: goal_checker
+    general_goal_checker:
+      plugin: "nav2_controller::SimpleGoalChecker"
+      xy_goal_tolerance: 0.35
+      yaw_goal_tolerance: 0.35
+      stateful: false
     controller_plugins: [FollowPath]
 
     # Progress checker parameters
@@ -135,9 +140,9 @@ controller_server:
     # Goal checker parameters
     goal_checker:
       plugin: nav2_controller::SimpleGoalChecker
-      xy_goal_tolerance: 0.50
-      yaw_goal_tolerance: 0.60
-      stateful: true
+      xy_goal_tolerance: 0.35
+      yaw_goal_tolerance: 0.35
+      stateful: false
 
     # MPPI controller
     FollowPath:
@@ -231,8 +236,8 @@ controller_server_rclcpp_node:
 local_costmap:
   local_costmap:
     ros__parameters:
-      update_frequency: 3.0
-      publish_frequency: 2.0
+      update_frequency: 10.0
+      publish_frequency: 5.0
       global_frame: odom
       robot_base_frame: base_link
       use_sim_time: false
@@ -241,19 +246,15 @@ local_costmap:
       width: 4
       height: 4
       resolution: 0.04
-      plugins: [static_layer, obstacle_layer, inflation_layer]
-      static_layer:
-        plugin: nav2_costmap_2d::StaticLayer
-        enabled: true
-        map_subscribe_transient_local: true
+      plugins: [obstacle_layer, inflation_layer]
       obstacle_layer:
-        plugin: "nav2_costmap_2d::ObstacleLayer"
+        plugin: nav2_costmap_2d::ObstacleLayer
         enabled: true
         footprint_clearing_enabled: true
         observation_sources: scan
         scan:
           topic: /scan_filtered
-          data_type: "LaserScan"
+          data_type: LaserScan
           marking: true
           clearing: true
           inf_is_valid: true
@@ -263,7 +264,7 @@ local_costmap:
       inflation_layer:
         plugin: nav2_costmap_2d::InflationLayer
         enabled: true
-        inflation_radius: 0.05
+        inflation_radius: 0.07
         cost_scaling_factor: 8.0
 
       robot_radius: 0.18
@@ -281,8 +282,8 @@ local_costmap:
 global_costmap:
   global_costmap:
     ros__parameters:
-      update_frequency: 1.0
-      publish_frequency: 1.0
+      update_frequency: 5.0
+      publish_frequency: 2.0
       global_frame: map
       robot_base_frame: base_link
       use_sim_time: false
@@ -295,13 +296,13 @@ global_costmap:
         enabled: true
         map_subscribe_transient_local: true
       obstacle_layer:
-        plugin: "nav2_costmap_2d::ObstacleLayer"
+        plugin: nav2_costmap_2d::ObstacleLayer
         enabled: true
         footprint_clearing_enabled: true
         observation_sources: scan
         scan:
           topic: /scan_filtered
-          data_type: "LaserScan"
+          data_type: LaserScan
           marking: true
           clearing: true
           inf_is_valid: true
@@ -311,7 +312,7 @@ global_costmap:
       inflation_layer:
         plugin: nav2_costmap_2d::InflationLayer
         enabled: true
-        inflation_radius: 0.05
+        inflation_radius: 0.07
         cost_scaling_factor: 8.0
       robot_radius: 0.18
       footprint_padding: 0.005

--- a/config/nav2_rpp_params.yaml
+++ b/config/nav2_rpp_params.yaml
@@ -121,7 +121,7 @@ controller_server:
   ros__parameters:
     use_sim_time: false
 
-    controller_frequency: 5.0
+    controller_frequency: 20.0
 
     # if velocity is below threshold value it is set to 0
     min_x_velocity_threshold: 0.01    # Measured
@@ -135,11 +135,16 @@ controller_server:
       movement_time_allowance: 10.0
 
     goal_checker_plugin: goal_checker
+    general_goal_checker:
+      plugin: "nav2_controller::SimpleGoalChecker"
+      xy_goal_tolerance: 0.35
+      yaw_goal_tolerance: 0.35
+      stateful: false
     goal_checker:
       plugin: nav2_controller::SimpleGoalChecker
-      xy_goal_tolerance: 0.50
-      yaw_goal_tolerance: 0.60
-      stateful: true # if stateful is True goal checker will not check if the xy position matches again once it is found to be True.
+      xy_goal_tolerance: 0.35
+      yaw_goal_tolerance: 0.35
+      stateful: false # if stateful is True goal checker will not check if the xy position matches again once it is found to be True.
 
     controller_plugins: [FollowPath]
     FollowPath:
@@ -201,8 +206,8 @@ local_costmap:
       global_frame: odom
       robot_base_frame: base_link
 
-      update_frequency: 3.0
-      publish_frequency: 2.0
+      update_frequency: 10.0
+      publish_frequency: 5.0
 
       width: 4
       height: 4
@@ -211,19 +216,15 @@ local_costmap:
       always_send_full_costmap: true
       rolling_window: true
 
-      plugins: [static_layer, obstacle_layer, inflation_layer]
-      static_layer:
-        plugin: nav2_costmap_2d::StaticLayer
-        enabled: true
-        map_subscribe_transient_local: true
+      plugins: [obstacle_layer, inflation_layer]
       obstacle_layer:
-        plugin: "nav2_costmap_2d::ObstacleLayer"
+        plugin: nav2_costmap_2d::ObstacleLayer
         enabled: true
         footprint_clearing_enabled: true
         observation_sources: scan
         scan:
           topic: /scan_filtered
-          data_type: "LaserScan"
+          data_type: LaserScan
           marking: true
           clearing: true
           inf_is_valid: true
@@ -233,7 +234,7 @@ local_costmap:
       inflation_layer:
         plugin: nav2_costmap_2d::InflationLayer
         enabled: true
-        inflation_radius: 0.05
+        inflation_radius: 0.07
         cost_scaling_factor: 8.0
 
       robot_radius: 0.18
@@ -255,8 +256,8 @@ global_costmap:
       global_frame: map
       robot_base_frame: base_link
 
-      update_frequency: 1.0
-      publish_frequency: 1.0
+      update_frequency: 5.0
+      publish_frequency: 2.0
 
       resolution: 0.05
 
@@ -269,13 +270,13 @@ global_costmap:
         enabled: true
         map_subscribe_transient_local: true
       obstacle_layer:
-        plugin: "nav2_costmap_2d::ObstacleLayer"
+        plugin: nav2_costmap_2d::ObstacleLayer
         enabled: true
         footprint_clearing_enabled: true
         observation_sources: scan
         scan:
           topic: /scan_filtered
-          data_type: "LaserScan"
+          data_type: LaserScan
           marking: true
           clearing: true
           inf_is_valid: true
@@ -285,7 +286,7 @@ global_costmap:
       inflation_layer:
         plugin: nav2_costmap_2d::InflationLayer
         enabled: true
-        inflation_radius: 0.05
+        inflation_radius: 0.07
         cost_scaling_factor: 8.0
 
       robot_radius: 0.18


### PR DESCRIPTION
## Summary
- replace the laser filter chain to mask the robot body and clean near-range readings
- retune Nav2 local and global costmaps plus goal tolerances across MPPI, RPP, and DWB configs
- switch the default controller to the RPP implementation in the environment configuration

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d66bcf9e8083238be44d3d8bda05bd