### PR TITLE
Switch default navigation controller back to MPPI

### DIFF
--- a/.env
+++ b/.env
@@ -36,7 +36,7 @@ SAVE_MAP_PERIOD=15
 # - dwb - DWB controller
 # - rpp - Regulated Pure Pursuit
 # - mppi - Model Predictive Path Integral
-CONTROLLER=rpp
+CONTROLLER=mppi
 
 # =======================================
 # Namespace / Husarnet config

--- a/config/nav2_mppi_params.yaml
+++ b/config/nav2_mppi_params.yaml
@@ -147,9 +147,9 @@ controller_server:
     # MPPI controller
     FollowPath:
       plugin: nav2_mppi_controller::MPPIController
-      time_steps: 30
-      model_dt: 0.2
-      batch_size: 500
+      time_steps: 56
+      model_dt: 0.05
+      batch_size: 1000
       vx_std: 0.2
       vy_std: 0.0
       wz_std: 0.35


### PR DESCRIPTION
## Summary
- set the default controller selection to MPPI so the compose setup loads the MPPI profile
- increase MPPI sampling horizon parameters to match the tuned costmap configuration

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d66efd34c88323b042f686d5c69b4f