### PR TITLE
Fix costmap obstacle source and waypoint handling

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -59,6 +59,7 @@ services:
     volumes:
       - ./config/nav2_${CONTROLLER:-rpp}_params.yaml:/params.yaml
       - ./maps:/maps
+      - ./scripts:/ros2_ws/scripts:ro
     environment:
       - MAP=${MAP:-r1}
     command: >

--- a/config/nav2_dwb_params.yaml
+++ b/config/nav2_dwb_params.yaml
@@ -238,14 +238,14 @@ local_costmap:
           marking: true
           clearing: true
           inf_is_valid: true
-          obstacle_range: 4.0
-          raytrace_range: 5.0
+          obstacle_range: 5.0
+          raytrace_range: 6.0
           observation_persistence: 0.0
       inflation_layer:
         plugin: nav2_costmap_2d::InflationLayer
         enabled: true
-        inflation_radius: 0.07
-        cost_scaling_factor: 8.0
+        inflation_radius: 0.10
+        cost_scaling_factor: 7.5
 
       always_send_full_costmap: true
 
@@ -277,14 +277,14 @@ global_costmap:
           marking: true
           clearing: true
           inf_is_valid: true
-          obstacle_range: 4.0
-          raytrace_range: 5.0
+          obstacle_range: 5.0
+          raytrace_range: 6.0
           observation_persistence: 0.0   # NO arrastre
       inflation_layer:
         plugin: nav2_costmap_2d::InflationLayer
         enabled: true
-        inflation_radius: 0.07
-        cost_scaling_factor: 8.0
+        inflation_radius: 0.10
+        cost_scaling_factor: 7.5
       always_send_full_costmap: true
 
 map_server:
@@ -444,13 +444,13 @@ robot_state_publisher:
 waypoint_follower:
   ros__parameters:
     use_sim_time: false
-    loop_rate: 5
+    loop_rate: 20
     stop_on_failure: false
-    waypoint_task_executor_plugin: wait_at_waypoint
+    waypoint_task_executor_plugin: "wait_at_waypoint"
     wait_at_waypoint:
-      plugin: nav2_waypoint_follower::WaitAtWaypoint
-      enabled: true
-      waypoint_pause_duration: 200
+      plugin: "nav2_waypoint_follower::WaitAtWaypoint"
+      enabled: false
+      waypoint_pause_duration: 0
 
 velocity_smoother:
   ros__parameters:

--- a/config/nav2_mppi_params.yaml
+++ b/config/nav2_mppi_params.yaml
@@ -258,14 +258,14 @@ local_costmap:
           marking: true
           clearing: true
           inf_is_valid: true
-          obstacle_range: 4.0
-          raytrace_range: 5.0
+          obstacle_range: 5.0
+          raytrace_range: 6.0
           observation_persistence: 0.0
       inflation_layer:
         plugin: nav2_costmap_2d::InflationLayer
         enabled: true
-        inflation_radius: 0.07
-        cost_scaling_factor: 8.0
+        inflation_radius: 0.10
+        cost_scaling_factor: 7.5
 
       robot_radius: 0.18
       footprint_padding: 0.005
@@ -306,14 +306,14 @@ global_costmap:
           marking: true
           clearing: true
           inf_is_valid: true
-          obstacle_range: 4.0
-          raytrace_range: 5.0
+          obstacle_range: 5.0
+          raytrace_range: 6.0
           observation_persistence: 0.0   # NO arrastre
       inflation_layer:
         plugin: nav2_costmap_2d::InflationLayer
         enabled: true
-        inflation_radius: 0.07
-        cost_scaling_factor: 8.0
+        inflation_radius: 0.10
+        cost_scaling_factor: 7.5
       robot_radius: 0.18
       footprint_padding: 0.005
       always_send_full_costmap: true
@@ -475,13 +475,14 @@ slam_toolbox:
 
 waypoint_follower:
   ros__parameters:
-    loop_rate: 5
+    use_sim_time: false
+    loop_rate: 20
     stop_on_failure: false
-    waypoint_task_executor_plugin: wait_at_waypoint
+    waypoint_task_executor_plugin: "wait_at_waypoint"
     wait_at_waypoint:
-      plugin: nav2_waypoint_follower::WaitAtWaypoint
-      enabled: true
-      waypoint_pause_duration: 200
+      plugin: "nav2_waypoint_follower::WaitAtWaypoint"
+      enabled: false
+      waypoint_pause_duration: 0
 
 velocity_smoother:
   ros__parameters:

--- a/config/nav2_rpp_params.yaml
+++ b/config/nav2_rpp_params.yaml
@@ -228,14 +228,14 @@ local_costmap:
           marking: true
           clearing: true
           inf_is_valid: true
-          obstacle_range: 4.0
-          raytrace_range: 5.0
+          obstacle_range: 5.0
+          raytrace_range: 6.0
           observation_persistence: 0.0
       inflation_layer:
         plugin: nav2_costmap_2d::InflationLayer
         enabled: true
-        inflation_radius: 0.07
-        cost_scaling_factor: 8.0
+        inflation_radius: 0.10
+        cost_scaling_factor: 7.5
 
       robot_radius: 0.18
       footprint_padding: 0.005
@@ -280,14 +280,14 @@ global_costmap:
           marking: true
           clearing: true
           inf_is_valid: true
-          obstacle_range: 4.0
-          raytrace_range: 5.0
+          obstacle_range: 5.0
+          raytrace_range: 6.0
           observation_persistence: 0.0   # NO arrastre
       inflation_layer:
         plugin: nav2_costmap_2d::InflationLayer
         enabled: true
-        inflation_radius: 0.07
-        cost_scaling_factor: 8.0
+        inflation_radius: 0.10
+        cost_scaling_factor: 7.5
 
       robot_radius: 0.18
       footprint_padding: 0.005
@@ -451,13 +451,13 @@ behavior_server:
 waypoint_follower:
   ros__parameters:
     use_sim_time: false
-    loop_rate: 5
+    loop_rate: 20
     stop_on_failure: false
-    waypoint_task_executor_plugin: wait_at_waypoint
+    waypoint_task_executor_plugin: "wait_at_waypoint"
     wait_at_waypoint:
-      plugin: nav2_waypoint_follower::WaitAtWaypoint
-      enabled: true
-      waypoint_pause_duration: 200
+      plugin: "nav2_waypoint_follower::WaitAtWaypoint"
+      enabled: false
+      waypoint_pause_duration: 0
 
 smoother_server:
   ros__parameters:

--- a/justfile
+++ b/justfile
@@ -188,20 +188,11 @@ start-route ruta="mi_ruta":
         ros2 action list | grep -Eq "/follow_waypoints|/navigate_through_poses" && exit 0; \
         sleep 1; done; echo "⛔  acciones de Nav2 no disponibles"; exit 1'
 
-    # 2b) Limpieza de costmaps sin bloquear (prueba ambos nombres, 1s de timeout)
-    @docker compose exec navigation bash -lc 'source /opt/ros/humble/setup.bash; \
-      for S in /local_costmap/clear_entire_costmap /local_costmap/clear_entirely_local_costmap; do \
-        if ros2 service list | grep -qx "$$S"; then \
-          timeout 1 ros2 service call "$$S" nav2_msgs/srv/ClearEntireCostmap "{}" || true; \
-          break; \
-        fi; \
-      done; \
-      for S in /global_costmap/clear_entire_costmap /global_costmap/clear_entirely_global_costmap; do \
-        if ros2 service list | grep -qx "$$S"; then \
-          timeout 1 ros2 service call "$$S" nav2_msgs/srv/ClearEntireCostmap "{}" || true; \
-          break; \
-        fi; \
-      done'
+    # 2b) Limpieza robusta de costmaps (intenta ambos servicios conocidos)
+    @docker compose exec navigation bash /ros2_ws/scripts/clear_costmaps.sh || true
+
+    # 2c) Verifica que los costmaps realmente están suscritos a /scan_filtered
+    @docker compose exec navigation bash -lc 'python3 /ros2_ws/scripts/nav2_guard.py'
 
     # 3) Lanza el reproductor de waypoints dentro de path_tools
     @just play-path {{ruta}}

--- a/scripts/clear_costmaps.sh
+++ b/scripts/clear_costmaps.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+source /opt/ros/humble/setup.bash
+
+clear_if_exists() {
+  local svc="$1"
+  if ros2 service list | grep -qx "$svc"; then
+    local typ
+    typ="$(ros2 service type "$svc" 2>/dev/null || true)"
+    [ -n "$typ" ] && timeout 6 ros2 service call "$svc" "$typ" "{}" || true
+  fi
+}
+
+# Local (ambos nombres posibles según versión Nav2)
+clear_if_exists /local_costmap/clear_entire_costmap
+clear_if_exists /local_costmap/clear_entirely_local_costmap
+
+# Global (ambos nombres posibles)
+clear_if_exists /global_costmap/clear_entire_costmap
+clear_if_exists /global_costmap/clear_entirely_global_costmap

--- a/scripts/nav2_guard.py
+++ b/scripts/nav2_guard.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+import subprocess
+import sys
+import time
+
+
+DEF_CHECK = "source /opt/ros/humble/setup.bash && ros2 topic info {topic} -v || true"
+
+def costmaps_subscribed(topic: str) -> bool:
+    try:
+        output = subprocess.check_output(
+            ["bash", "-lc", DEF_CHECK.format(topic=topic)],
+            text=True,
+        )
+    except subprocess.CalledProcessError:
+        return False
+    return "/local_costmap" in output and "/global_costmap" in output
+
+
+def wait_for_costmaps(topic: str, attempts: int = 10, delay: float = 1.0) -> bool:
+    for _ in range(attempts):
+        if costmaps_subscribed(topic):
+            return True
+        time.sleep(delay)
+    return False
+
+
+def main() -> int:
+    topic = "/scan_filtered"
+    if not wait_for_costmaps(topic):
+        print(
+            f"\u26d4  {topic} NO está suscrito por los costmaps. Revisa 'topic: /scan_filtered' en los YAML.",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"\u2705  {topic} OK: costmaps suscritos.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- extend the obstacle layer scan configuration and inflation tuning across all Nav2 parameter profiles
- disable waypoint follower pauses and add guard/cleanup scripts for costmap sanity checks
- mount the scripts into the navigation container and invoke them from `just start-route`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d674bc3a188323aceb80bd38ba0237