### PR TITLE
Alinea Nav2 con /scan_filtered y añade utilidades NTP

### DIFF
--- a/config/nav2_dwb_params.yaml
+++ b/config/nav2_dwb_params.yaml
@@ -221,14 +221,15 @@ local_costmap:
       use_sim_time: false
       transform_tolerance: 0.30
       rolling_window: true
-      width: 2
-      height: 2
-      resolution: 0.04
+      width: 4.0
+      height: 4.0
+      resolution: 0.05
       robot_radius: 0.18
-      footprint_padding: 0.005
+      footprint_padding: 0.01
       plugins: [obstacle_layer, inflation_layer]
+
       obstacle_layer:
-        plugin: nav2_costmap_2d::ObstacleLayer
+        plugin: "nav2_costmap_2d::ObstacleLayer"
         enabled: true
         footprint_clearing_enabled: true
         observation_sources: scan
@@ -238,14 +239,18 @@ local_costmap:
           marking: true
           clearing: true
           inf_is_valid: true
-          obstacle_range: 5.0
-          raytrace_range: 6.0
+          obstacle_min_range: 0.05
+          obstacle_max_range: 6.0
+          raytrace_min_range: 0.0
+          raytrace_max_range: 7.0
           observation_persistence: 0.0
+          expected_update_rate: 0.0
+
       inflation_layer:
-        plugin: nav2_costmap_2d::InflationLayer
+        plugin: "nav2_costmap_2d::InflationLayer"
         enabled: true
         inflation_radius: 0.10
-        cost_scaling_factor: 7.5
+        cost_scaling_factor: 6.0
 
       always_send_full_costmap: true
 
@@ -259,32 +264,18 @@ global_costmap:
       use_sim_time: false
       transform_tolerance: 0.30
       robot_radius: 0.18
-      footprint_padding: 0.005
+      footprint_padding: 0.01
       resolution: 0.05
       track_unknown_space: true
-      plugins: [static_layer, obstacle_layer, inflation_layer]
+      plugins: [static_layer, inflation_layer]
       static_layer:
         plugin: nav2_costmap_2d::StaticLayer
         map_subscribe_transient_local: true
-      obstacle_layer:
-        plugin: nav2_costmap_2d::ObstacleLayer
-        enabled: true
-        footprint_clearing_enabled: true
-        observation_sources: scan
-        scan:
-          topic: /scan_filtered
-          data_type: LaserScan
-          marking: true
-          clearing: true
-          inf_is_valid: true
-          obstacle_range: 5.0
-          raytrace_range: 6.0
-          observation_persistence: 0.0   # NO arrastre
       inflation_layer:
-        plugin: nav2_costmap_2d::InflationLayer
+        plugin: "nav2_costmap_2d::InflationLayer"
         enabled: true
-        inflation_radius: 0.10
-        cost_scaling_factor: 7.5
+        inflation_radius: 0.12
+        cost_scaling_factor: 4.0
       always_send_full_costmap: true
 
 map_server:
@@ -446,11 +437,10 @@ waypoint_follower:
     use_sim_time: false
     loop_rate: 20
     stop_on_failure: false
-    waypoint_task_executor_plugin: "wait_at_waypoint"
-    wait_at_waypoint:
+    waypoint_task_executor:
       plugin: "nav2_waypoint_follower::WaitAtWaypoint"
-      enabled: false
-      waypoint_pause_duration: 0
+      enabled: true
+      wait_duration: 0.0s
 
 velocity_smoother:
   ros__parameters:

--- a/config/nav2_mppi_params.yaml
+++ b/config/nav2_mppi_params.yaml
@@ -243,12 +243,13 @@ local_costmap:
       use_sim_time: false
       transform_tolerance: 0.30
       rolling_window: true
-      width: 4
-      height: 4
-      resolution: 0.04
+      width: 4.0
+      height: 4.0
+      resolution: 0.05
       plugins: [obstacle_layer, inflation_layer]
+
       obstacle_layer:
-        plugin: nav2_costmap_2d::ObstacleLayer
+        plugin: "nav2_costmap_2d::ObstacleLayer"
         enabled: true
         footprint_clearing_enabled: true
         observation_sources: scan
@@ -258,17 +259,21 @@ local_costmap:
           marking: true
           clearing: true
           inf_is_valid: true
-          obstacle_range: 5.0
-          raytrace_range: 6.0
+          obstacle_min_range: 0.05
+          obstacle_max_range: 6.0
+          raytrace_min_range: 0.0
+          raytrace_max_range: 7.0
           observation_persistence: 0.0
+          expected_update_rate: 0.0
+
       inflation_layer:
-        plugin: nav2_costmap_2d::InflationLayer
+        plugin: "nav2_costmap_2d::InflationLayer"
         enabled: true
         inflation_radius: 0.10
-        cost_scaling_factor: 7.5
+        cost_scaling_factor: 6.0
 
       robot_radius: 0.18
-      footprint_padding: 0.005
+      footprint_padding: 0.01
 
       always_send_full_costmap: true
 
@@ -290,32 +295,18 @@ global_costmap:
       transform_tolerance: 0.30
       resolution: 0.05
       track_unknown_space: true
-      plugins: [static_layer, obstacle_layer, inflation_layer]
+      plugins: [static_layer, inflation_layer]
       static_layer:
         plugin: nav2_costmap_2d::StaticLayer
         enabled: true
         map_subscribe_transient_local: true
-      obstacle_layer:
-        plugin: nav2_costmap_2d::ObstacleLayer
-        enabled: true
-        footprint_clearing_enabled: true
-        observation_sources: scan
-        scan:
-          topic: /scan_filtered
-          data_type: LaserScan
-          marking: true
-          clearing: true
-          inf_is_valid: true
-          obstacle_range: 5.0
-          raytrace_range: 6.0
-          observation_persistence: 0.0   # NO arrastre
       inflation_layer:
-        plugin: nav2_costmap_2d::InflationLayer
+        plugin: "nav2_costmap_2d::InflationLayer"
         enabled: true
-        inflation_radius: 0.10
-        cost_scaling_factor: 7.5
+        inflation_radius: 0.12
+        cost_scaling_factor: 4.0
       robot_radius: 0.18
-      footprint_padding: 0.005
+      footprint_padding: 0.01
       always_send_full_costmap: true
   global_costmap_client:
     ros__parameters:
@@ -478,11 +469,10 @@ waypoint_follower:
     use_sim_time: false
     loop_rate: 20
     stop_on_failure: false
-    waypoint_task_executor_plugin: "wait_at_waypoint"
-    wait_at_waypoint:
+    waypoint_task_executor:
       plugin: "nav2_waypoint_follower::WaitAtWaypoint"
-      enabled: false
-      waypoint_pause_duration: 0
+      enabled: true
+      wait_duration: 0.0s
 
 velocity_smoother:
   ros__parameters:

--- a/config/nav2_rpp_params.yaml
+++ b/config/nav2_rpp_params.yaml
@@ -209,16 +209,17 @@ local_costmap:
       update_frequency: 10.0
       publish_frequency: 5.0
 
-      width: 4
-      height: 4
-      resolution: 0.04
+      width: 4.0
+      height: 4.0
+      resolution: 0.05
 
       always_send_full_costmap: true
       rolling_window: true
 
       plugins: [obstacle_layer, inflation_layer]
+
       obstacle_layer:
-        plugin: nav2_costmap_2d::ObstacleLayer
+        plugin: "nav2_costmap_2d::ObstacleLayer"
         enabled: true
         footprint_clearing_enabled: true
         observation_sources: scan
@@ -228,17 +229,21 @@ local_costmap:
           marking: true
           clearing: true
           inf_is_valid: true
-          obstacle_range: 5.0
-          raytrace_range: 6.0
+          obstacle_min_range: 0.05
+          obstacle_max_range: 6.0
+          raytrace_min_range: 0.0
+          raytrace_max_range: 7.0
           observation_persistence: 0.0
+          expected_update_rate: 0.0
+
       inflation_layer:
-        plugin: nav2_costmap_2d::InflationLayer
+        plugin: "nav2_costmap_2d::InflationLayer"
         enabled: true
         inflation_radius: 0.10
-        cost_scaling_factor: 7.5
+        cost_scaling_factor: 6.0
 
       robot_radius: 0.18
-      footprint_padding: 0.005
+      footprint_padding: 0.01
 
   local_costmap_client:
     ros__parameters:
@@ -264,33 +269,19 @@ global_costmap:
       always_send_full_costmap: true
       track_unknown_space: true # if False, treats unknown space as free space, else as unknown space
 
-      plugins: [static_layer, obstacle_layer, inflation_layer]
+      plugins: [static_layer, inflation_layer]
       static_layer:
         plugin: nav2_costmap_2d::StaticLayer
         enabled: true
         map_subscribe_transient_local: true
-      obstacle_layer:
-        plugin: nav2_costmap_2d::ObstacleLayer
-        enabled: true
-        footprint_clearing_enabled: true
-        observation_sources: scan
-        scan:
-          topic: /scan_filtered
-          data_type: LaserScan
-          marking: true
-          clearing: true
-          inf_is_valid: true
-          obstacle_range: 5.0
-          raytrace_range: 6.0
-          observation_persistence: 0.0   # NO arrastre
       inflation_layer:
-        plugin: nav2_costmap_2d::InflationLayer
+        plugin: "nav2_costmap_2d::InflationLayer"
         enabled: true
-        inflation_radius: 0.10
-        cost_scaling_factor: 7.5
+        inflation_radius: 0.12
+        cost_scaling_factor: 4.0
 
       robot_radius: 0.18
-      footprint_padding: 0.005
+      footprint_padding: 0.01
 
   global_costmap_client:
     ros__parameters:
@@ -453,11 +444,10 @@ waypoint_follower:
     use_sim_time: false
     loop_rate: 20
     stop_on_failure: false
-    waypoint_task_executor_plugin: "wait_at_waypoint"
-    wait_at_waypoint:
+    waypoint_task_executor:
       plugin: "nav2_waypoint_follower::WaitAtWaypoint"
-      enabled: false
-      waypoint_pause_duration: 0
+      enabled: true
+      wait_duration: 0.0s
 
 smoother_server:
   ros__parameters:

--- a/justfile
+++ b/justfile
@@ -152,6 +152,21 @@ teleop:
     @echo "╰───────────────────────────────────────────"
     docker attach $(docker compose -f compose.yaml -f docker-compose.override.yml ps -q teleop)
 
+diag-scan:
+    @docker compose exec rplidar bash -lc 'source /opt/ros/humble/setup.bash; \
+      echo "--- topics ---"; ros2 topic list | grep -E "/scan($|_)"; \
+      echo "--- /scan_filtered info ---"; ros2 topic info /scan_filtered || true; \
+      echo "--- 1 mensaje ---"; ros2 topic echo -n1 /scan_filtered || true'
+
+diag-costmaps:
+    @docker compose exec navigation bash -lc 'source /opt/ros/humble/setup.bash; \
+      echo "--- local costmap observation_sources ---"; \
+      ros2 param get /local_costmap/local_costmap obstacle_layer.observation_sources || true; \
+      echo "--- local costmap scan.topic ---"; \
+      ros2 param get /local_costmap/local_costmap obstacle_layer.scan.topic || true; \
+      echo "--- plugins local ---"; \
+      ros2 param get /local_costmap/local_costmap plugins || true'
+
 # ------------------ Rutas grabadas ---------------------------------
 
 # Grabar un recorrido con teleoperación activa
@@ -168,6 +183,11 @@ play-path name:
         bash -c "source /opt/ros/humble/setup.bash && \
                  python3 /scripts/path_player.py \
                  --file /routes/{{name}}.yaml"
+
+play-ntp name:
+    @docker compose exec path_tools \
+      bash -lc 'source /opt/ros/humble/setup.bash && \
+                python3 /scripts/path_player_ntp.py --file /routes/{{name}}.yaml'
 # ────────────────────────────────────────────────────────────────
 #  start-route  →  Arranca ROSbot con mapa fijo y reproduce una ruta
 #     Uso:  just start-route mi_ruta        # (omite la extensión .yaml)
@@ -196,6 +216,15 @@ start-route ruta="mi_ruta":
 
     # 3) Lanza el reproductor de waypoints dentro de path_tools
     @just play-path {{ruta}}
+
+start-route-ntp ruta="mi_ruta":
+    @SLAM=False docker compose -f compose.yaml up -d
+    @echo "⌛  Esperando a Nav2..."
+    @bash -lc 'for i in {1..30}; do docker compose ps navigation | grep -q "(healthy)" && exit 0; sleep 2; done; echo "⛔ navigation no healthy"; exit 1'
+    @docker compose exec navigation bash -lc 'source /opt/ros/humble/setup.bash; \
+      for i in $(seq 1 30); do ros2 action list | grep -q "/navigate_through_poses" && exit 0; sleep 1; done; exit 1'
+    @just diag-costmaps
+    @just play-ntp {{ruta}}
 
 # ────────────────────────────────────────────────────────────────
 #  ruta1  →  atajo sin parámetros. Equivale a:

--- a/scripts/path_player_ntp.py
+++ b/scripts/path_player_ntp.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+import sys
+import yaml
+
+import rclpy
+from rclpy.action import ActionClient
+from rclpy.node import Node
+
+from geometry_msgs.msg import PoseStamped
+from nav2_msgs.action import NavigateThroughPoses
+
+
+class PlayerNTP(Node):
+    def __init__(self, yaml_file: str) -> None:
+        super().__init__('path_player_ntp')
+        self.cli = ActionClient(self, NavigateThroughPoses, '/navigate_through_poses')
+        self.get_logger().info(f"Leyendo {yaml_file}")
+
+        with open(yaml_file, 'r', encoding='utf-8') as f:
+            data = yaml.safe_load(f)
+
+        poses = []
+        for wp in data.get('waypoints', []):
+            ps = PoseStamped()
+            ps.header.frame_id = 'map'
+            ps.pose.position.x = float(wp['x'])
+            ps.pose.position.y = float(wp['y'])
+            ps.pose.orientation.z = float(wp.get('oz', 0.0))
+            ps.pose.orientation.w = float(wp.get('ow', 1.0))
+            poses.append(ps)
+
+        rclpy.spin_until_future_complete(self, self.cli.wait_for_server())
+
+        goal = NavigateThroughPoses.Goal()
+        goal.poses = poses
+
+        self.get_logger().info(f"🚀 Enviando NTP con {len(poses)} poses")
+        send_future = self.cli.send_goal_async(goal)
+        send_future.add_done_callback(self._goal_sent)
+
+    def _goal_sent(self, future):
+        goal_handle = future.result()
+        if not goal_handle.accepted:
+            self.get_logger().error('❌ NTP no aceptado')
+            rclpy.shutdown()
+            return
+
+        self.get_logger().info('✅ NTP aceptado')
+        result_future = goal_handle.get_result_async()
+        result_future.add_done_callback(self._goal_finished)
+
+    def _goal_finished(self, future):
+        _ = future.result()
+        self.get_logger().info('🏁 NTP terminado')
+        rclpy.shutdown()
+
+
+def main() -> None:
+    if '--file' not in sys.argv:
+        print('Uso: path_player_ntp.py --file /routes/mi_ruta.yaml')
+        sys.exit(1)
+
+    yaml_path = sys.argv[sys.argv.index('--file') + 1]
+
+    rclpy.init()
+    node = PlayerNTP(yaml_path)
+    rclpy.spin(node)
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/fix_lidar_and_local_costmap.sh
+++ b/tools/fix_lidar_and_local_costmap.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+shopt -s nullglob
+YAMLS=(config/nav2_*_params.yaml)
+command -v yq >/dev/null || { echo "Instala yq primero"; exit 1; }
+
+for F in "${YAMLS[@]}"; do
+  echo "→ parcheando $F"
+  yq -i '
+    .amcl.ros__parameters.scan_topic = "/scan_filtered" |
+
+    .local_costmap.ros__parameters.plugins = ["obstacle_layer","inflation_layer"] |
+    .local_costmap.ros__parameters.obstacle_layer.plugin = "nav2_costmap_2d::ObstacleLayer" |
+    .local_costmap.ros__parameters.obstacle_layer.enabled = true |
+    .local_costmap.ros__parameters.obstacle_layer.footprint_clearing_enabled = true |
+    .local_costmap.ros__parameters.obstacle_layer.observation_sources = "scan" |
+    .local_costmap.ros__parameters.obstacle_layer.scan.topic = "/scan_filtered" |
+    .local_costmap.ros__parameters.obstacle_layer.scan.data_type = "LaserScan" |
+    .local_costmap.ros__parameters.obstacle_layer.scan.marking = true |
+    .local_costmap.ros__parameters.obstacle_layer.scan.clearing = true |
+    .local_costmap.ros__parameters.obstacle_layer.scan.inf_is_valid = true |
+    .local_costmap.ros__parameters.obstacle_layer.scan.obstacle_min_range = 0.05 |
+    .local_costmap.ros__parameters.obstacle_layer.scan.obstacle_max_range = 6.0 |
+    .local_costmap.ros__parameters.obstacle_layer.scan.raytrace_min_range = 0.0 |
+    .local_costmap.ros__parameters.obstacle_layer.scan.raytrace_max_range = 7.0 |
+    .local_costmap.ros__parameters.obstacle_layer.scan.observation_persistence = 0.0 |
+    .local_costmap.ros__parameters.obstacle_layer.scan.expected_update_rate = 0.0 |
+    .local_costmap.ros__parameters.inflation_layer.plugin = "nav2_costmap_2d::InflationLayer" |
+    .local_costmap.ros__parameters.inflation_layer.enabled = true |
+    .local_costmap.ros__parameters.inflation_layer.inflation_radius = 0.10 |
+    .local_costmap.ros__parameters.inflation_layer.cost_scaling_factor = 6.0 |
+
+    .waypoint_follower.ros__parameters.stop_on_failure = false |
+    .waypoint_follower.ros__parameters.waypoint_task_executor.plugin = "nav2_waypoint_follower::WaitAtWaypoint" |
+    .waypoint_follower.ros__parameters.waypoint_task_executor.enabled = true |
+    .waypoint_follower.ros__parameters.waypoint_task_executor.wait_duration = "0.0s"
+  ' "$F"
+done
+
+echo "✓ Listo. Reinicia sólo navegación:  docker compose restart navigation"


### PR DESCRIPTION
## Summary
- actualiza los tres perfiles de Nav2 para forzar /scan_filtered en AMCL y costmaps locales con mayor alcance del láser y parametrización de inflación revisada
- elimina las paradas artificiales del waypoint follower unificando la configuración en los tres YAML
- añade comandos just de diagnóstico y ejecución NavigateThroughPoses junto con scripts auxiliares para reproducir rutas y parchear los YAML

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d67c7fd2c483239da5f05fd5607a13