### PR TITLE
Increase MPPI costmap safety margins

### DIFF
--- a/config/nav2_mppi_params.yaml
+++ b/config/nav2_mppi_params.yaml
@@ -258,17 +258,17 @@ local_costmap:
           marking: true
           clearing: true
           inf_is_valid: true
-          obstacle_range: 5.0
-          raytrace_range: 6.0
+          obstacle_range: 6.0
+          raytrace_range: 7.0
           observation_persistence: 0.0
       inflation_layer:
         plugin: nav2_costmap_2d::InflationLayer
         enabled: true
-        inflation_radius: 0.10
-        cost_scaling_factor: 7.5
+        inflation_radius: 0.17
+        cost_scaling_factor: 4.0
 
       robot_radius: 0.18
-      footprint_padding: 0.005
+      footprint_padding: 0.03
 
       always_send_full_costmap: true
 
@@ -312,8 +312,8 @@ global_costmap:
       inflation_layer:
         plugin: nav2_costmap_2d::InflationLayer
         enabled: true
-        inflation_radius: 0.10
-        cost_scaling_factor: 7.5
+        inflation_radius: 0.15
+        cost_scaling_factor: 5.0
       robot_radius: 0.18
       footprint_padding: 0.005
       always_send_full_costmap: true


### PR DESCRIPTION
## Summary
- expand local costmap inflation and footprint padding for greater clearance around obstacles
- extend lidar obstacle and raytrace ranges so the controller reacts sooner
- make the global costmap inflation slightly more conservative to support safer global plans

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc19abecc883239c2546b2303727fc