### PR TITLE
Revert controller updates to restore previous Nav2 configuration

### DIFF
--- a/.env
+++ b/.env
@@ -36,7 +36,7 @@ SAVE_MAP_PERIOD=15
 # - dwb - DWB controller
 # - rpp - Regulated Pure Pursuit
 # - mppi - Model Predictive Path Integral
-CONTROLLER=dwb
+CONTROLLER=mppi
 
 # =======================================
 # Namespace / Husarnet config

--- a/config/nav2_dwb_params.yaml
+++ b/config/nav2_dwb_params.yaml
@@ -143,9 +143,13 @@ bt_navigator_navigate_to_pose_rclcpp_node:
 controller_server:
   ros__parameters:
     use_sim_time: false
-    controller_frequency: 20.0
+    controller_frequency: 5.0
+    min_x_velocity_threshold: 0.001
+    min_y_velocity_threshold: 0.5
+    min_theta_velocity_threshold: 0.001
+    failure_tolerance: 0.3
     progress_checker_plugin: progress_checker
-    goal_checker_plugin: general_goal_checker
+    goal_checker_plugins: [general_goal_checker]   # "precise_goal_checker"
     controller_plugins: [FollowPath]
 
     # Progress checker parameters
@@ -153,26 +157,48 @@ controller_server:
       plugin: nav2_controller::SimpleProgressChecker
       required_movement_radius: 0.5
       movement_time_allowance: 10.0
-
+    # Goal checker parameters
+    #precise_goal_checker:
+    #  plugin: "nav2_controller::SimpleGoalChecker"
+    #  xy_goal_tolerance: 0.25
+    #  yaw_goal_tolerance: 0.25
+    #  stateful: True
     general_goal_checker:
-      plugin: nav2_controller::SimpleGoalChecker
       stateful: true
+      plugin: nav2_controller::SimpleGoalChecker
       xy_goal_tolerance: 0.50
       yaw_goal_tolerance: 0.60
-
     # DWB parameters
     FollowPath:
       plugin: dwb_core::DWBLocalPlanner
-      debug_trajectory_details: false
+      debug_trajectory_details: true
       min_vel_x: 0.0
-      max_vel_x: 0.5
       min_vel_y: 0.0
+      max_vel_x: 0.4
       max_vel_y: 0.0
-      max_vel_theta: 1.5
+      max_vel_theta: 1.0
+      min_speed_xy: 0.0
+      max_speed_xy: 0.5
+      min_speed_theta: 0.0
+      # Add high threshold velocity for turtlebot 3 issue.
+      # https://github.com/ROBOTIS-GIT/turtlebot3_simulations/issues/75
       acc_lim_x: 1.0
+      acc_lim_y: 0.0
       acc_lim_theta: 3.2
-      vx_samples: 20
-      vtheta_samples: 40
+      decel_lim_x: -1.0
+      decel_lim_y: 0.0
+      decel_lim_theta: -3.2
+      vx_samples: 12
+      vy_samples: 1
+      vtheta_samples: 12
+      sim_time: 1.5
+      linear_granularity: 0.1
+      angular_granularity: 0.1
+      transform_tolerance: 0.25
+      xy_goal_tolerance: 0.2
+      trans_stopped_velocity: 0.25
+      short_circuit_trajectory_evaluation: true
+      stateful: true
       critics: [RotateToGoal, Oscillation, BaseObstacle, GoalAlign, PathAlign, PathDist, GoalDist]
       BaseObstacle.scale: 0.02
       PathAlign.scale: 32.0
@@ -199,7 +225,7 @@ local_costmap:
       height: 2
       resolution: 0.04
       robot_radius: 0.18
-      footprint_padding: 0.05
+      footprint_padding: 0.005
       plugins: [obstacle_layer, inflation_layer]
       obstacle_layer:
         plugin: nav2_costmap_2d::ObstacleLayer
@@ -218,8 +244,8 @@ local_costmap:
       inflation_layer:
         plugin: nav2_costmap_2d::InflationLayer
         enabled: true
-        inflation_radius: 0.20
-        cost_scaling_factor: 3.0
+        inflation_radius: 0.10
+        cost_scaling_factor: 7.5
 
       always_send_full_costmap: true
 
@@ -233,7 +259,7 @@ global_costmap:
       use_sim_time: false
       transform_tolerance: 0.30
       robot_radius: 0.18
-      footprint_padding: 0.05
+      footprint_padding: 0.005
       resolution: 0.05
       track_unknown_space: true
       plugins: [static_layer, obstacle_layer, inflation_layer]
@@ -253,12 +279,12 @@ global_costmap:
           inf_is_valid: true
           obstacle_range: 5.0
           raytrace_range: 6.0
-          observation_persistence: 0.0
+          observation_persistence: 0.0   # NO arrastre
       inflation_layer:
         plugin: nav2_costmap_2d::InflationLayer
         enabled: true
-        inflation_radius: 0.15
-        cost_scaling_factor: 5.0
+        inflation_radius: 0.10
+        cost_scaling_factor: 7.5
       always_send_full_costmap: true
 
 map_server:


### PR DESCRIPTION
## Summary
- revert the Nav2 configuration changes introduced when switching the controller to DWB
- restore the controller selection in the environment configuration to the previous MPPI setting

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd0626b6c08323ba4d2fe56a3dce4b