### PR TITLE
Tune MPPI to prioritize obstacle avoidance

### DIFF
--- a/config/nav2_mppi_params.yaml
+++ b/config/nav2_mppi_params.yaml
@@ -147,16 +147,17 @@ controller_server:
     # MPPI controller
     FollowPath:
       plugin: nav2_mppi_controller::MPPIController
+      # muestreo / dinámica (seguros para ROSbot XL)
       time_steps: 56
       model_dt: 0.05
-      batch_size: 1000
-      vx_std: 0.2
-      vy_std: 0.0
+      batch_size: 1200
+      vx_std: 0.20
+      vy_std: 0.0          # diferencial ⇒ sin lateral
       wz_std: 0.35
-      vx_max: 0.3
-      vx_min: -0.2
+      vx_max: 0.30
+      vx_min: -0.20
       vy_max: 0.0
-      wz_max: 0.7
+      wz_max: 0.75
       iteration_count: 1
       prune_distance: 1.8
       transform_tolerance: 0.25
@@ -164,15 +165,22 @@ controller_server:
       gamma: 0.015
       motion_model: DiffDrive
       visualize: false
-      reset_period: 1.0 # (only in Humble)
+      reset_period: 1.0
       regenerate_noises: false
       TrajectoryVisualizer:
         trajectory_step: 5
         time_step: 5
-      AckermannConstrains:
-        min_turning_r: 0.05
-      critics: [ConstraintCritic, ObstaclesCritic, GoalCritic, GoalAngleCritic, PathAlignCritic, PathFollowCritic,
-        PathAngleCritic, PreferForwardCritic]
+      # IMPORTANTE: obstáculos por encima de "seguir el camino"
+      critics: [ConstraintCritic, CostCritic, ObstaclesCritic, GoalCritic, GoalAngleCritic, PathAlignCritic, PathFollowCritic, PathAngleCritic, PreferForwardCritic]
+      CostCritic:
+        enabled: true
+        cost_power: 1
+        cost_weight: 5.0
+        critical_cost: 253.0
+        consider_footprint: true
+        collision_cost: 1000000.0
+        near_goal_distance: 0.8
+        trajectory_point_step: 2
       ConstraintCritic:
         enabled: true
         cost_power: 1
@@ -180,7 +188,7 @@ controller_server:
       GoalCritic:
         enabled: true
         cost_power: 1
-        cost_weight: 25.0
+        cost_weight: 5.0         # ↓ para que no gane a los obstáculos
         threshold_to_consider: 1.0
       GoalAngleCritic:
         enabled: true
@@ -195,19 +203,19 @@ controller_server:
       ObstaclesCritic:
         enabled: true
         cost_power: 1
-        cost_weight: 3.0
-        repulsion_weight: 1.5
-        critical_weight: 20.0
-        consider_footprint: false
-        collision_cost: 10000.0
-        collision_margin_distance: 0.10
+        cost_weight: 8.0          # <<< MUCHO más peso
+        repulsion_weight: 2.5
+        critical_weight: 40.0
+        consider_footprint: true  # <<< sin esto puede “rozar”
+        collision_cost: 1000000.0
+        collision_margin_distance: 0.20
         near_goal_distance: 0.5
-        inflation_radius: 0.55 # (only in Humble)
-        cost_scaling_factor: 3.0 # (only in Humble)
+        inflation_radius: 0.30
+        cost_scaling_factor: 3.0
       PathAlignCritic:
         enabled: true
         cost_power: 1
-        cost_weight: 2.0
+        cost_weight: 6.0
         max_path_occupancy_ratio: 0.05
         trajectory_point_step: 3
         threshold_to_consider: 0.5
@@ -215,13 +223,13 @@ controller_server:
       PathFollowCritic:
         enabled: true
         cost_power: 1
-        cost_weight: 2.0
+        cost_weight: 4.0
         offset_from_furthest: 5
         threshold_to_consider: 1.0
       PathAngleCritic:
         enabled: true
         cost_power: 1
-        cost_weight: 1.0
+        cost_weight: 2.0
         offset_from_furthest: 4
         threshold_to_consider: 0.5
         max_angle_to_furthest: 1.0
@@ -246,7 +254,7 @@ local_costmap:
       rolling_window: true
       width: 4
       height: 4
-      resolution: 0.04
+      resolution: 0.05
       plugins: [obstacle_layer, inflation_layer]
       obstacle_layer:
         plugin: nav2_costmap_2d::ObstacleLayer
@@ -261,15 +269,15 @@ local_costmap:
           inf_is_valid: true
           obstacle_range: 6.5
           raytrace_range: 8.0
-          observation_persistence: 0.40
+          observation_persistence: 0.30
       inflation_layer:
         plugin: nav2_costmap_2d::InflationLayer
         enabled: true
-        inflation_radius: 0.22
+        inflation_radius: 0.25
         cost_scaling_factor: 3.0
 
       robot_radius: 0.18
-      footprint_padding: 0.05
+      footprint_padding: 0.06
 
       always_send_full_costmap: true
 
@@ -309,11 +317,11 @@ global_costmap:
           inf_is_valid: true
           obstacle_range: 5.0
           raytrace_range: 6.0
-          observation_persistence: 0.35
+          observation_persistence: 0.30
       inflation_layer:
         plugin: nav2_costmap_2d::InflationLayer
         enabled: true
-        inflation_radius: 0.15
+        inflation_radius: 0.20
         cost_scaling_factor: 5.0
       robot_radius: 0.18
       footprint_padding: 0.005


### PR DESCRIPTION
## Summary
- increase the obstacle-related critics in the MPPI controller and enable the cost critic so obstacles dominate over goal tracking
- widen the local inflation footprint and padding to give the robot more clearance without closing doorways
- reduce costmap observation persistence to make obstacle sightings decay faster when cleared

## Testing
- not run (environment lacks `just` command)


------
https://chatgpt.com/codex/tasks/task_e_68dd0d1615488323a11e5dbb00c665d9