### PR TITLE
Build navigation stack from upstream Navigation2 repository

### DIFF
--- a/Dockerfile.navigation
+++ b/Dockerfile.navigation
@@ -1,0 +1,54 @@
+# syntax=docker/dockerfile:1.4
+#
+# Navigation stack image that overlays the upstream Navigation2 repository
+# (https://github.com/ros-navigation/navigation2) on top of the Husarion
+# base image.  The overlay workspace is built from the Humble branch so that
+# MPPI controller updates are always in sync with upstream.
+ARG BASE_IMAGE=husarion/navigation2:humble-1.1.12-20240123
+FROM ${BASE_IMAGE} AS navigation2
+
+ARG NAV2_BRANCH=humble
+ARG NAV2_REMOTE=https://github.com/ros-navigation/navigation2.git
+ENV NAV2_OVERLAY_WS=/navigation2_ws
+ENV NAV2_OVERLAY_SETUP=${NAV2_OVERLAY_WS}/install/setup.bash
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Install build essentials for pulling Navigation2 from source.
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create overlay workspace and fetch upstream Navigation2.
+RUN mkdir -p ${NAV2_OVERLAY_WS}/src
+WORKDIR ${NAV2_OVERLAY_WS}/src
+RUN git clone --branch ${NAV2_BRANCH} --depth 1 ${NAV2_REMOTE} navigation2
+
+# Build only the Navigation2 packages we need on top of the Husarion base
+# workspace.
+WORKDIR ${NAV2_OVERLAY_WS}
+RUN source /opt/ros/humble/setup.bash \
+    && colcon build --symlink-install \
+        --event-handlers console_cohesion+ console_direct+ \
+        --packages-up-to nav2_mppi_controller nav2_bt_navigator \
+            nav2_controller nav2_planner nav2_smoother \
+    && rm -rf log
+
+# Ensure interactive shells and the default ROS entrypoint source the overlay.
+RUN echo "source ${NAV2_OVERLAY_SETUP}" >> /etc/skel/.bashrc \
+    && echo "source ${NAV2_OVERLAY_SETUP}" >> /root/.bashrc
+
+RUN if [ -d /ros_entrypoint.d ]; then \
+      printf '#!/bin/bash\nsource %s\n' "${NAV2_OVERLAY_SETUP}" \
+        > /ros_entrypoint.d/50-navigation2-overlay.sh \
+        && chmod +x /ros_entrypoint.d/50-navigation2-overlay.sh; \
+    else \
+      echo "source ${NAV2_OVERLAY_SETUP}" >> /ros_entrypoint.sh; \
+    fi
+
+# Provide the checked-out commit hash for debugging purposes.
+RUN git -C ${NAV2_OVERLAY_WS}/src/navigation2 rev-parse HEAD \
+    > ${NAV2_OVERLAY_WS}/NAV2_COMMIT
+
+WORKDIR /

--- a/README.md
+++ b/README.md
@@ -135,6 +135,22 @@ http://rosbotxl:8080/ui
 > [!NOTE]
 > `rosbotxl` is the name of device set in Husarnet.
 
+## 🔗 Navigation2 upstream integration
+
+The `navigation` and `path_tools` containers now rebuild the
+[Navigation2](https://github.com/ros-navigation/navigation2/tree/humble)
+stack from source so that the MPPI controller and related plugins always
+match the upstream Humble branch.  Docker Compose takes care of cloning
+the repository and compiling the overlay workspace during
+`docker compose build navigation` (or automatically on the first
+`docker compose up`).  Set the `NAV2_BRANCH` build argument if you need a
+different branch or fork.
+
+- To replay a Navigate Through Poses route with the upstream stack, run
+  `just start ntp <nombre_ruta>`.
+- Traditional waypoint playback remains available via
+  `just start route <nombre_ruta>`.
+
 ---
 
 ## Simulation

--- a/compose.simulation.yaml
+++ b/compose.simulation.yaml
@@ -12,6 +12,14 @@ x-cpu-config:
     - DISPLAY=${DISPLAY:?err}
     - LIBGL_ALWAYS_SOFTWARE=1
 
+x-nav2-image: &nav2-image
+  build:
+    context: .
+    dockerfile: Dockerfile.navigation
+    args:
+      NAV2_BRANCH: humble
+  image: rosbot-navigation2:humble-source
+
 services:
 
   rosbot:
@@ -22,18 +30,21 @@ services:
     command: ${SIMULATION_COMMAND:-ros2 launch rosbot_xl_gazebo simulation.launch.py mecanum:=${MECANUM:-True}}
 
   navigation:
-    image: husarion/navigation2:humble-1.1.12-20240123
+    <<: *nav2-image
     volumes:
       - ./config/nav2_${CONTROLLER:-rpp}_params.yaml:/params.yaml
       - ./maps:/maps
     environment:
       - SAVE_MAP_PERIOD=${SAVE_MAP_PERIOD}
     command: >
-      ros2 launch nav2_bringup bringup_launch.py
-        slam:=${SLAM:-True}
-        params_file:=/params.yaml
-        map:=/maps/map.yaml
-        use_sim_time:=True
+      bash -lc "source /opt/ros/humble/setup.bash &&
+        source /ros2_ws/install/setup.bash &&
+        source ${NAV2_OVERLAY_SETUP:-/navigation2_ws/install/setup.bash} &&
+        ros2 launch nav2_bringup bringup_launch.py \
+          slam:=${SLAM:-True} \
+          params_file:=/params.yaml \
+          map:=/maps/map.yaml \
+          use_sim_time:=True"
 
   foxglove:
     image: husarion/foxglove:1.84.0

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,3 +1,11 @@
+x-nav2-image: &nav2-image
+  build:
+    context: .
+    dockerfile: Dockerfile.navigation
+    args:
+      NAV2_BRANCH: humble
+  image: rosbot-navigation2:humble-source
+
 services:
 
   rosbot:
@@ -51,7 +59,7 @@ services:
       - rplidar
 
   navigation:
-    image: husarion/navigation2:humble-1.1.12-20240123
+    <<: *nav2-image
     restart: unless-stopped
     depends_on:
       rplidar: { condition: service_started }
@@ -63,14 +71,17 @@ services:
     environment:
       - MAP=${MAP:-r1}
     command: >
-      ros2 launch /husarion_utils/bringup_launch.py
-        slam:=${SLAM:-True}
-        params_file:=/params.yaml
-        map:=/maps/${MAP:-r1}.yaml
-        use_sim_time:=False
+      bash -lc "source /opt/ros/humble/setup.bash &&
+        source /ros2_ws/install/setup.bash &&
+        source ${NAV2_OVERLAY_SETUP:-/navigation2_ws/install/setup.bash} &&
+        ros2 launch /husarion_utils/bringup_launch.py \
+          slam:=${SLAM:-True} \
+          params_file:=/params.yaml \
+          map:=/maps/${MAP:-r1}.yaml \
+          use_sim_time:=False"
 
   path_tools:
-    image: husarion/navigation2:humble-1.1.12-20240123
+    <<: *nav2-image
     network_mode: host
     restart: unless-stopped
     environment: [ ROS_DOMAIN_ID=0 ]
@@ -78,7 +89,11 @@ services:
       - ./routes:/routes
       - ./scripts:/scripts:ro
     # load the ROS environment before idling
-    command: bash -c "source /opt/ros/humble/setup.bash && sleep infinity"
+    command: >
+      bash -lc "source /opt/ros/humble/setup.bash &&
+        source /ros2_ws/install/setup.bash &&
+        source ${NAV2_OVERLAY_SETUP:-/navigation2_ws/install/setup.bash} &&
+        sleep infinity"
     depends_on:
       navigation: { condition: service_started }
 

--- a/justfile
+++ b/justfile
@@ -11,9 +11,6 @@ alias flash := flash-firmware
 [private]
 alias rosbot := start-rosbot
 [private]
-alias start := start-rosbot
-
-[private]
 gazebo: (start-simulation "gazebo")
 
 [private]
@@ -86,6 +83,37 @@ start-simulation engine="gazebo": _run-as-user
     docker compose -f compose.simulation.yaml down
     docker compose -f compose.simulation.yaml pull
     docker compose -f compose.simulation.yaml up
+
+start mode="" route="":
+    #!/bin/bash
+    just_cmd=(just)
+    if [[ -n "${JUSTFILE}" ]]; then
+      just_cmd+=(--justfile "${JUSTFILE}")
+    fi
+    case "${mode}" in
+      ""|"rosbot")
+        exec "${just_cmd[@]}" start-rosbot
+        ;;
+      "route")
+        if [[ -z "${route}" ]]; then
+          echo "Uso: just start route <nombre_ruta>" >&2
+          exit 1
+        fi
+        exec "${just_cmd[@]}" start-route "${route}"
+        ;;
+      "ntp")
+        if [[ -z "${route}" ]]; then
+          echo "Uso: just start ntp <nombre_ruta>" >&2
+          exit 1
+        fi
+        exec "${just_cmd[@]}" start-ntp "${route}"
+        ;;
+      *)
+        echo "Modo desconocido: ${mode}" >&2
+        echo "Usa: just start [rosbot|route|ntp] <nombre_ruta>" >&2
+        exit 1
+        ;;
+    esac
 
 # Restart the Nav2 container
 restart-navigation: _run-as-user


### PR DESCRIPTION
## Summary
- add a Dockerfile that builds an overlay workspace from the ros-navigation/navigation2 humble branch
- update both compose files to use the locally built Navigation2 image and source the overlay in runtime commands
- expose a friendly `just start` dispatcher and document the new Navigate Through Poses workflow in the README

## Testing
- not run (docker is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68dd100d362483238f21efbebd97eaca