### PR TITLE
Refresh ROS 2 apt key before installing git

### DIFF
--- a/Dockerfile.navigation
+++ b/Dockerfile.navigation
@@ -14,6 +14,14 @@ ENV NAV2_OVERLAY_SETUP=${NAV2_OVERLAY_WS}/install/setup.bash
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
+# Refresh the ROS 2 apt repository key to avoid signature expiration errors
+# when installing additional packages in derived layers.
+RUN curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key \
+    | gpg --dearmor -o /usr/share/keyrings/ros-archive-keyring.gpg \
+    && printf "deb [arch=%s signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu %s main\n" \
+        "$(dpkg --print-architecture)" "$(. /etc/os-release && echo "$UBUNTU_CODENAME")" \
+        > /etc/apt/sources.list.d/ros2.list
+
 # Install build essentials for pulling Navigation2 from source.
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## Summary
- refresh the ROS 2 apt repository key in the navigation overlay image to avoid signature expiration errors
- ensure the refreshed key is written to the ros2.list sources file before running apt-get

## Testing
- not run (environment does not provide Docker)


------
https://chatgpt.com/codex/tasks/task_e_68dd1263652883239934c0f268a357b4