### PR TITLE
Revert MPPI controller configuration alignment

### DIFF
--- a/config/nav2_mppi_params.yaml
+++ b/config/nav2_mppi_params.yaml
@@ -144,14 +144,15 @@ controller_server:
       yaw_goal_tolerance: 0.35
       stateful: false
 
-    # MPPI controller (sincronizado con nav2_mppi_controller de Navigation2)
+    # MPPI controller
     FollowPath:
       plugin: nav2_mppi_controller::MPPIController
+      # muestreo / dinámica (seguros para ROSbot XL)
       time_steps: 56
       model_dt: 0.05
       batch_size: 1200
-      vx_std: 0.2
-      vy_std: 0.0
+      vx_std: 0.20
+      vy_std: 0.0          # diferencial ⇒ sin lateral
       wz_std: 0.35
       vx_max: 0.30
       vx_min: -0.20
@@ -169,11 +170,8 @@ controller_server:
       TrajectoryVisualizer:
         trajectory_step: 5
         time_step: 5
+      # IMPORTANTE: obstáculos por encima de "seguir el camino"
       critics: [ConstraintCritic, CostCritic, ObstaclesCritic, GoalCritic, GoalAngleCritic, PathAlignCritic, PathFollowCritic, PathAngleCritic, PreferForwardCritic]
-      ConstraintCritic:
-        enabled: true
-        cost_power: 1
-        cost_weight: 2.0
       CostCritic:
         enabled: true
         cost_power: 1
@@ -183,23 +181,32 @@ controller_server:
         collision_cost: 1000000.0
         near_goal_distance: 0.8
         trajectory_point_step: 2
+      ConstraintCritic:
+        enabled: true
+        cost_power: 1
+        cost_weight: 2.0
       GoalCritic:
         enabled: true
         cost_power: 1
-        cost_weight: 5.0
+        cost_weight: 5.0         # ↓ para que no gane a los obstáculos
         threshold_to_consider: 1.0
       GoalAngleCritic:
         enabled: true
         cost_power: 1
         cost_weight: 3.0
         threshold_to_consider: 0.5
+      PreferForwardCritic:
+        enabled: true
+        cost_power: 1
+        cost_weight: 5.0
+        threshold_to_consider: 0.5
       ObstaclesCritic:
         enabled: true
         cost_power: 1
-        cost_weight: 8.0
+        cost_weight: 8.0          # <<< MUCHO más peso
         repulsion_weight: 2.5
         critical_weight: 40.0
-        consider_footprint: true
+        consider_footprint: true  # <<< sin esto puede “rozar”
         collision_cost: 1000000.0
         collision_margin_distance: 0.20
         near_goal_distance: 0.5
@@ -226,11 +233,6 @@ controller_server:
         offset_from_furthest: 4
         threshold_to_consider: 0.5
         max_angle_to_furthest: 1.0
-      PreferForwardCritic:
-        enabled: true
-        cost_power: 1
-        cost_weight: 5.0
-        threshold_to_consider: 0.5
       # TwirlingCritic:
       #   enabled: true
       #   twirling_cost_power: 1

--- a/config/nav2_mppi_webots_params.yaml
+++ b/config/nav2_mppi_webots_params.yaml
@@ -140,7 +140,7 @@ controller_server:
       yaw_goal_tolerance: 0.25
       stateful: true
 
-    # MPPI controller (sincronizado con nav2_mppi_controller de Navigation2)
+    # MPPI controller
     FollowPath:
       plugin: nav2_mppi_controller::MPPIController
       time_steps: 30
@@ -160,47 +160,45 @@ controller_server:
       gamma: 0.015
       motion_model: DiffDrive
       visualize: false
-      reset_period: 1.0
+      reset_period: 1.0 # (only in Humble)
       regenerate_noises: false
       TrajectoryVisualizer:
         trajectory_step: 5
         time_step: 5
-      critics: [ConstraintCritic, CostCritic, ObstaclesCritic, GoalCritic, GoalAngleCritic, PathAlignCritic, PathFollowCritic, PathAngleCritic, PreferForwardCritic]
+      AckermannConstrains:
+        min_turning_r: 0.05
+      critics: [ConstraintCritic, ObstaclesCritic, GoalCritic, GoalAngleCritic, PathAlignCritic, PathFollowCritic,
+        PathAngleCritic, PreferForwardCritic]
       ConstraintCritic:
         enabled: true
         cost_power: 1
         cost_weight: 2.0
-      CostCritic:
-        enabled: true
-        cost_power: 1
-        cost_weight: 5.0
-        critical_cost: 253.0
-        consider_footprint: true
-        collision_cost: 1000000.0
-        near_goal_distance: 0.8
-        trajectory_point_step: 2
       GoalCritic:
         enabled: true
         cost_power: 1
-        cost_weight: 5.0
+        cost_weight: 25.0
         threshold_to_consider: 1.0
       GoalAngleCritic:
         enabled: true
         cost_power: 1
         cost_weight: 3.0
         threshold_to_consider: 0.5
+      PreferForwardCritic:
+        enabled: true
+        cost_power: 1
+        cost_weight: 5.0
+        threshold_to_consider: 0.5
       ObstaclesCritic:
         enabled: true
         cost_power: 1
-        cost_weight: 8.0
-        repulsion_weight: 2.5
-        critical_weight: 40.0
-        consider_footprint: true
-        collision_cost: 1000000.0
-        collision_margin_distance: 0.20
+        repulsion_weight: 1.5
+        critical_weight: 20.0
+        consider_footprint: false
+        collision_cost: 10000.0
+        collision_margin_distance: 0.10
         near_goal_distance: 0.5
-        inflation_radius: 0.55
-        cost_scaling_factor: 3.0
+        inflation_radius: 0.55 # (only in Humble)
+        cost_scaling_factor: 3.0 # (only in Humble)
       PathAlignCritic:
         enabled: true
         cost_power: 1
@@ -222,11 +220,6 @@ controller_server:
         offset_from_furthest: 4
         threshold_to_consider: 0.5
         max_angle_to_furthest: 1.0
-      PreferForwardCritic:
-        enabled: true
-        cost_power: 1
-        cost_weight: 5.0
-        threshold_to_consider: 0.5
       # TwirlingCritic:
       #   enabled: true
       #   twirling_cost_power: 1

--- a/justfile
+++ b/justfile
@@ -182,7 +182,7 @@ play-ntp name:
 # ────────────────────────────────────────────────────────────────
 start-route ruta="mi_ruta":
     # 1) Levanta sólo compose.yaml (sin el override ⇒ no arranca teleop)
-    @SLAM=False CONTROLLER=mppi docker compose -f compose.yaml up -d
+    @SLAM=False docker compose -f compose.yaml up -d
 
     # 2) Espera a que el servicio navigation aparezca sano (máx 60 s)
     @echo "⌛  Esperando a Nav2..."
@@ -211,7 +211,7 @@ start-route ruta="mi_ruta":
 ## ───────────────────────────────────────────────────────────────
 start-ntp ruta="mi_ruta":
     # 1) Levanta solo compose.yaml (sin override ⇒ no teleop)
-    @SLAM=False CONTROLLER=mppi docker compose -f compose.yaml up -d
+    @SLAM=False docker compose -f compose.yaml up -d
 
     # 2) Espera a Nav2 'healthy'
     @echo "⌛  Esperando a Nav2..."


### PR DESCRIPTION
## Summary
- restore the MPPI controller parameter files to the state prior to aligning them with Navigation2 defaults
- remove the CONTROLLER environment override from the Just recipes to match the previous configuration

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd47111f208323a0fa9c6705fdb5cd