### PR TITLE
Configure MPPI critics

### DIFF
--- a/config/nav2_mppi_params.yaml
+++ b/config/nav2_mppi_params.yaml
@@ -173,64 +173,21 @@ controller_server:
         time_step: 5
       AckermannConstraints:
         min_turning_r: 0.05
-      critics: [ConstraintCritic, ObstaclesCritic, GoalCritic, GoalAngleCritic, PathAlignCritic, PathFollowCritic,
-        PathAngleCritic, PreferForwardCritic]
-      ConstraintCritic:
-        enabled: true
-        cost_power: 1
-        cost_weight: 2.0
-      GoalCritic:
-        enabled: true
-        cost_power: 1
-        cost_weight: 6.0
-        threshold_to_consider: 1.0
-      GoalAngleCritic:
-        enabled: true
-        cost_power: 1
-        cost_weight: 3.0
-        threshold_to_consider: 0.5
-      PreferForwardCritic:
-        enabled: true
-        cost_power: 1
-        cost_weight: 5.0
-        threshold_to_consider: 0.5
+      critics: ["ObstaclesCritic", "ConstraintCritic",
+        "PathAlignCritic", "PathFollowCritic",
+        "GoalCritic", "PreferForwardCritic", "TwirlingCritic"]
+
       ObstaclesCritic:
-        enabled: true
-        cost_power: 1
-        cost_weight: 3.0
-        repulsion_weight: 1.5
-        critical_weight: 20.0
+        weight: 5.0
         consider_footprint: true
-        collision_cost: 1000000.0
-        collision_margin_distance: 0.12
-        near_goal_distance: 0.5
-        inflation_radius: 0.22
-        cost_scaling_factor: 3.0
-      PathAlignCritic:
-        enabled: true
-        cost_power: 1
-        cost_weight: 8.0
-        max_path_occupancy_ratio: 0.07
-        trajectory_point_step: 4
-        threshold_to_consider: 0.5
-        offset_from_furthest: 20
-      PathFollowCritic:
-        enabled: true
-        cost_power: 1
-        cost_weight: 5.0
-        offset_from_furthest: 5
-        threshold_to_consider: 1.2
-      PathAngleCritic:
-        enabled: true
-        cost_power: 1
-        cost_weight: 1.0
-        offset_from_furthest: 4
-        threshold_to_consider: 0.5
-        max_angle_to_furthest: 1.0
-      # TwirlingCritic:
-      #   enabled: true
-      #   twirling_cost_power: 1
-      #   twirling_cost_weight: 10.0
+        collision_margin_distance: 0.10
+
+      PathAlignCritic:   {weight: 10.0}
+      PathFollowCritic:  {weight: 6.0}
+      GoalCritic:        {weight: 3.0}
+      PreferForwardCritic: {weight: 5.0}
+      ConstraintCritic:  {weight: 1.0}
+      TwirlingCritic:    {weight: 2.0}
 
 controller_server_rclcpp_node:
   ros__parameters:


### PR DESCRIPTION
## Summary
- update the MPPI FollowPath controller to use the modern critic list including ObstaclesCritic
- configure baseline weights and footprint collision margin for the critics

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de42443724832391eba4526179d6dc