### PR TITLE
Add odom/tf diagnostic and bridge targets

### DIFF
--- a/justfile
+++ b/justfile
@@ -240,3 +240,76 @@ start-ntp ruta="mi_ruta":
 # ────────────────────────────────────────────────────────────────
 ruta1:
     just start-route mi_ruta
+
+# --- Diagnóstico ODOM/TF sin y con Nav2 ------------------------
+diag-odom-tf:
+    @echo "▶ Drivers + Lidar + Filtro"
+    docker compose up -d rosbot rplidar scan_filter
+    @echo ""
+    @echo "▶ Chequeos dentro de 'rosbot'"
+    docker compose exec rosbot bash -lc '\
+      source /opt/ros/humble/setup.bash; \
+      echo "== Odometry topics =="; ros2 topic list | grep -E "/odom$|/odometry/filtered$" || true; \
+      echo "== info /rosbot_xl_base_controller/odom =="; ros2 topic info -v /rosbot_xl_base_controller/odom || true; \
+      echo "== info /odometry/filtered ==";             ros2 topic info -v /odometry/filtered || true; \
+      echo "== hz /rosbot_xl_base_controller/odom (8s) =="; timeout 8 ros2 topic hz /rosbot_xl_base_controller/odom || true; \
+      echo "== hz /odometry/filtered (8s) ==";             timeout 8 ros2 topic hz /odometry/filtered || true; \
+      echo "== TF odom->base_link (8s) ==";                 timeout 8 ros2 run tf2_ros tf2_echo odom base_link || true'
+    @echo ""
+    @echo "▶ Lanzando Nav2 (para map->odom)"
+    docker compose up -d navigation
+    @echo ""
+    @echo "▶ Chequeos dentro de 'navigation'"
+    docker compose exec navigation bash -lc '\
+      source /opt/ros/humble/setup.bash; \
+      echo "== TF map->odom (8s) ==";       timeout 8 ros2 run tf2_ros tf2_echo map odom || true; \
+      echo "== TF odom->base_link (8s) =="; timeout 8 ros2 run tf2_ros tf2_echo odom base_link || true'
+
+# --- Bridge temporal ODOM→TF -----------------------------------
+bridge-odom-tf:
+    @docker compose exec -T rosbot bash -lc '\
+      source /opt/ros/humble/setup.bash; \
+      cat >/tmp/odom_tf_bridge.py << "PY" \
+import rclpy
+from rclpy.node import Node
+from nav_msgs.msg import Odometry
+from tf2_ros import TransformBroadcaster
+from geometry_msgs.msg import TransformStamped
+
+SRC_TOPICS = ["/rosbot_xl_base_controller/odom", "/odometry/filtered"]
+
+class OdomTFBridge(Node):
+    def __init__(self):
+        super().__init__("odom_tf_bridge")
+        self.br = TransformBroadcaster(self)
+        self.pub = self.create_publisher(Odometry, "/odom", 10)
+        self.subs = [self.create_subscription(Odometry, t, self.cb, 10) for t in SRC_TOPICS]
+        self.get_logger().info(f"Esperando odometría en: {SRC_TOPICS}")
+
+    def cb(self, msg: Odometry):
+        # Normaliza a odom/base_link
+        msg.header.frame_id = "odom"
+        if not msg.child_frame_id:
+            msg.child_frame_id = "base_link"
+        self.pub.publish(msg)
+        t = TransformStamped()
+        t.header.stamp = self.get_clock().now().to_msg()
+        t.header.frame_id = "odom"
+        t.child_frame_id  = msg.child_frame_id
+        t.transform.translation.x = msg.pose.pose.position.x
+        t.transform.translation.y = msg.pose.pose.position.y
+        t.transform.translation.z = msg.pose.pose.position.z
+        t.transform.rotation      = msg.pose.pose.orientation
+        self.br.sendTransform(t)
+
+rclpy.init()
+try:
+    rclpy.spin(OdomTFBridge())
+finally:
+    rclpy.shutdown()
+PY
+      nohup python3 /tmp/odom_tf_bridge.py >/tmp/odom_tf_bridge.log 2>&1 & \
+      && echo "▶ odom_tf_bridge lanzado (background)"; \
+      sleep 1; \
+      timeout 8 ros2 run tf2_ros tf2_echo odom base_link || true'
+


### PR DESCRIPTION
## Summary
- add a `diag-odom-tf` just target to spin up core containers and inspect odometry topics and TF availability
- add a `bridge-odom-tf` just target that republishes odometry and broadcasts the odom→base_link transform as a temporary workaround

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3aeb101e0832385555deff23720ba