### PR TITLE
Add EKF configuration for odom to base_link TF

### DIFF
--- a/config/ekf.yaml
+++ b/config/ekf.yaml
@@ -1,0 +1,32 @@
+ekf_filter_node:
+  ros__parameters:
+    use_sim_time: false
+    two_d_mode: true
+    publish_tf: true
+    map_frame: map
+    odom_frame: odom
+    base_link_frame: base_link
+    world_frame: odom
+
+    frequency: 50.0
+    sensor_timeout: 0.1
+
+    # Entradas típicas del Rosbot XL (ajusta si tus topics difieren)
+    odom0: /rosbot_xl_base_controller/odom
+    odom0_config: [true, true, false,
+                   false, false, true,
+                   false, false, false,
+                   false, false, false,
+                   false, false, false]
+    odom0_differential: false
+    odom0_queue_size: 10
+
+    imu0: /imu/data
+    imu0_config: [false, false, false,
+                  true,  true,  true,
+                  false, false, false,
+                  false, false, false,
+                  false, false, false]
+    imu0_differential: false
+    imu0_remove_gravitational_acceleration: true
+    imu0_queue_size: 50


### PR DESCRIPTION
## Summary
- add a minimal EKF configuration for 2D odometry fusion with IMU and wheel odometry
- enable TF publication from odom to base_link with tuned frames and topics

## Testing
- not run (configuration only)


------
https://chatgpt.com/codex/tasks/task_e_68e550ad7adc8323b10cdfa297ccb644