### PR TITLE
Ensure teleop stack uses EKF config and Foxglove host override

### DIFF
--- a/config/ekf.yaml
+++ b/config/ekf.yaml
@@ -1,6 +1,6 @@
-ekf_filter_node:
+ekf_node:
   ros__parameters:
-    use_sim_time: false
+    frequency: 30.0
     two_d_mode: true
     publish_tf: true
     map_frame: map
@@ -8,25 +8,27 @@ ekf_filter_node:
     base_link_frame: base_link
     world_frame: odom
 
-    frequency: 50.0
-    sensor_timeout: 0.1
-
-    # Entradas típicas del Rosbot XL (ajusta si tus topics difieren)
+    # Usa la odometría del controlador de base
     odom0: /rosbot_xl_base_controller/odom
-    odom0_config: [true, true, false,
-                   false, false, true,
-                   false, false, false,
-                   false, false, false,
-                   false, false, false]
-    odom0_differential: false
     odom0_queue_size: 10
+    odom0_differential: false
+    odom0_nodelay: true
 
-    imu0: /imu/data
-    imu0_config: [false, false, false,
-                  true,  true,  true,
-                  false, false, false,
-                  false, false, false,
-                  false, false, false]
-    imu0_differential: false
-    imu0_remove_gravitational_acceleration: true
-    imu0_queue_size: 50
+    # Configuración de variables usadas (pose x,y,yaw y twist vx,vyaw)
+    odom0_config: [true,  true,  false,
+                   false, false, true,
+                   true,  true,  false,
+                   false, false, true,
+                   false, false, false]
+
+    # Si más adelante quieres fusionar IMU, descomenta estas líneas
+    # imu0: /imu/data
+    # imu0_queue_size: 10
+    # imu0_remove_gravitational_acceleration: true
+    # imu0_nodelay: true
+    # imu0_differential: false
+    # imu0_config: [false, false, false,
+    #               true,  true,  true,
+    #               false, false, false,
+    #               false, false, true,
+    #               false, false, false]

--- a/ekf-config.override.yml
+++ b/ekf-config.override.yml
@@ -1,0 +1,16 @@
+services:
+  ekf:
+    image: husarion/navigation2:humble-1.1.12-20240123
+    network_mode: host
+    restart: unless-stopped
+    environment:
+      - ROS_DOMAIN_ID=0
+      - RMW_IMPLEMENTATION=rmw_fastrtps_cpp
+    volumes:
+      - ./config/ekf.yaml:/config/ekf.yaml:ro
+    depends_on:
+      - rosbot
+    command: >
+      bash -lc "source /opt/ros/humble/setup.bash &&
+                ros2 run robot_localization ekf_node
+                  --ros-args --params-file /config/ekf.yaml"

--- a/foxglove-hostfix.override.yml
+++ b/foxglove-hostfix.override.yml
@@ -1,0 +1,4 @@
+services:
+  foxglove:
+    environment:
+      - DS_HOST=127.0.0.1

--- a/justfile
+++ b/justfile
@@ -143,7 +143,7 @@ _install-yq:
 
 teleop:
     @echo "Starting sensors + SLAM + teleop…"
-    docker compose -f compose.yaml -f docker-compose.override.yml up -d \
+    docker compose -f compose.yaml -f docker-compose.override.yml -f foxglove-hostfix.override.yml -f ekf-config.override.yml up -d \
       rosbot rplidar navigation microros scan_filter ekf foxglove foxglove-ds teleop
     @echo ""
     @echo "╭───────────────────────────────────────────"
@@ -151,7 +151,7 @@ teleop:
     @echo "│          A/D = girar;  Q/E = giro suave"
     @echo "│  Salir sin matar:  Ctrl-P  Ctrl-Q"
     @echo "╰───────────────────────────────────────────"
-    docker attach $(docker compose -f compose.yaml -f docker-compose.override.yml ps -q teleop)
+    docker attach $(docker compose -f compose.yaml -f docker-compose.override.yml -f foxglove-hostfix.override.yml -f ekf-config.override.yml ps -q teleop)
 
 # ------------------ Rutas grabadas ---------------------------------
 


### PR DESCRIPTION
## Summary
- update the teleop Just recipe to include the EKF and Foxglove host fix compose overrides
- add a compose override that forces Foxglove to use DS_HOST=127.0.0.1 in host mode
- replace the EKF parameters with a minimal odom-based configuration and provide an override to mount it explicitly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e7a86ff4c483239346718724f614e0