### PR TITLE
Escape LAUNCH_PID references in compose override

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -15,7 +15,7 @@ services:
         ros2 launch rosbot_xl_bringup bringup.launch.py
           mecanum:=${MECANUM:-True}
           depthai_params_file:=/config/oak_1080p.yaml &
-        LAUNCH_PID=$!;
+        LAUNCH_PID=$$!;
         # Espera a que el controller_manager exponga servicios
         until ros2 service list | grep -q '/controller_manager/list_controllers'; do sleep 0.5; done;
         # Spawners (idempotentes)
@@ -23,7 +23,7 @@ services:
           --controller-manager /controller_manager --controller-manager-timeout 120 || true;
         ros2 run controller_manager spawner rosbot_xl_base_controller \
           --controller-manager /controller_manager --controller-manager-timeout 120 || true;
-        wait $LAUNCH_PID
+        wait $$LAUNCH_PID
       "
 
   rplidar:


### PR DESCRIPTION
## Summary
- escape shell variable usage so docker compose does not try to expand LAUNCH_PID on the host

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e7afc098008323b09dfffc28692c03