### PR TITLE
Add robot_localization EKF to navigation stack

### DIFF
--- a/Dockerfile.navigation
+++ b/Dockerfile.navigation
@@ -1,0 +1,5 @@
+FROM husarion/navigation2:humble-1.1.12-20240123
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ros-humble-robot-localization && \
+    rm -rf /var/lib/apt/lists/*

--- a/README.md
+++ b/README.md
@@ -120,10 +120,29 @@ if your hardware requires a different configuration.
   [m-explore-ros2](https://github.com/robo-friends/m-explore-ros2) repository
   and launches automatically with this command.
 
-   The parameters used by `explore_lite` are stored in
-   `config/explore_params.yaml`.  Edit this file to adjust options such as
-   `planner_frequency` or `progress_timeout` and restart the Compose stack to
-   apply the changes.
+ The parameters used by `explore_lite` are stored in
+  `config/explore_params.yaml`.  Edit this file to adjust options such as
+  `planner_frequency` or `progress_timeout` and restart the Compose stack to
+  apply the changes.
+
+#### Extended Kalman Filter for odometry fusion
+
+The navigation container now launches the
+[`robot_localization`](https://docs.ros.org/en/rolling/p/robot_localization/)
+`ekf_node` alongside Nav2.  The filter fuses wheel odometry from
+`/odometry/wheels` with the IMU data published on `/imu_broadcaster/imu` and
+publishes the fused estimate on `/odometry/filtered` while also maintaining the
+`odom → base_link` transform.
+
+- The filter parameters live in `config/ekf.yaml`.  Update the topic names if
+  your robot exposes different interfaces and restart the Compose stack for the
+  changes to take effect.
+- The Docker image used by the navigation service is built locally from
+  `Dockerfile.navigation`, which installs the `ros-humble-robot-localization`
+  package required by the EKF node.
+- The launch helper script `scripts/start_navigation_with_ekf.sh` starts the EKF
+  before running the Husarion bring-up launch file so the transform tree is
+  ready when Nav2 activates.
 
 ### 🚗 Step 5: Control the ROSbot from a Web Browser
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -51,23 +51,21 @@ services:
       - rplidar
 
   navigation:
-    image: husarion/navigation2:humble-1.1.12-20240123
+    build:
+      context: .
+      dockerfile: Dockerfile.navigation
     restart: unless-stopped
     depends_on:
       rplidar: { condition: service_started }
       rosbot:  { condition: service_started }
     volumes:
       - ./config/nav2_${CONTROLLER:-rpp}_params.yaml:/params.yaml
+      - ./config/ekf.yaml:/config/ekf.yaml:ro
       - ./maps:/maps
       - ./scripts:/ros2_ws/scripts:ro
     environment:
       - MAP=${MAP:-r1}
-    command: >
-      ros2 launch /husarion_utils/bringup_launch.py
-        slam:=${SLAM:-True}
-        params_file:=/params.yaml
-        map:=/maps/${MAP:-r1}.yaml
-        use_sim_time:=False
+    command: /ros2_ws/scripts/start_navigation_with_ekf.sh
 
   path_tools:
     image: husarion/navigation2:humble-1.1.12-20240123

--- a/config/ekf.yaml
+++ b/config/ekf.yaml
@@ -1,0 +1,23 @@
+ekf_node:
+  ros__parameters:
+    frequency: 30.0
+    two_d_mode: true
+    publish_tf: true
+    map_frame: "map"
+    odom_frame: "odom"
+    base_link_frame: "base_link"
+    world_frame: "odom"
+
+    odom0: "/odometry/wheels"
+    odom0_config: [false, false, false,
+                   false, false, false,
+                   true,  true,  false,
+                   false, false, true,
+                   false, false, false]
+
+    imu0: "/imu_broadcaster/imu"
+    imu0_config: [false, false, false,
+                  false, false, false,
+                  false, false, false,
+                  false, false, true,
+                  false, false, false]

--- a/scripts/start_navigation_with_ekf.sh
+++ b/scripts/start_navigation_with_ekf.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -euo pipefail
+
+source /opt/ros/humble/setup.bash
+if [ -f "/ros2_ws/install/setup.bash" ]; then
+  source /ros2_ws/install/setup.bash
+fi
+
+ros2 run robot_localization ekf_node --ros-args --params-file /config/ekf.yaml &
+EKF_PID=$!
+trap 'kill "${EKF_PID}" 2>/dev/null || true' EXIT
+
+ros2 launch /husarion_utils/bringup_launch.py \
+  slam:=${SLAM:-True} \
+  params_file:=/params.yaml \
+  map:=/maps/${MAP:-r1}.yaml \
+  use_sim_time:=False


### PR DESCRIPTION
## Summary
- add a navigation Dockerfile that installs the robot_localization package
- launch the EKF node alongside Nav2 using a helper script and dedicated parameter file
- document the new localization setup and configuration entry points in the README

## Testing
- not run (not applicable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e7d9129c38832386808c58c9ab999a