### PR TITLE
Refresh ROS 2 apt key for navigation image

### DIFF
--- a/Dockerfile.navigation
+++ b/Dockerfile.navigation
@@ -1,5 +1,19 @@
 FROM husarion/navigation2:humble-1.1.12-20240123
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends ros-humble-robot-localization && \
+# Refresh the ROS 2 apt repository key (the old one expired) and install the EKF package.
+RUN set -euo pipefail; \
+    rm -f /etc/apt/sources.list.d/ros2.list /etc/apt/sources.list.d/ros2-latest.list; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends ca-certificates curl; \
+    rm -rf /var/lib/apt/lists/*; \
+    mkdir -p /usr/share/keyrings; \
+    curl -fsSL https://raw.githubusercontent.com/ros/rosdistro/master/ros-archive-keyring.gpg \
+      -o /usr/share/keyrings/ros-archive-keyring.gpg; \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] \
+      http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo \"${UBUNTU_CODENAME}\") main" \
+      > /etc/apt/sources.list.d/ros2.list
+
+RUN set -euo pipefail; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends ros-humble-robot-localization; \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
- refresh the ROS 2 apt repository key in the navigation image build and reinstall ros-humble-robot-localization
- ensure the EKF dependency can be installed when building the navigation container

## Testing
- not run (Docker is unavailable in the test environment)


------
https://chatgpt.com/codex/tasks/task_e_68e7e03e0b548323927e389992e6d446