### PR TITLE
Fix ROS key download path in navigation Dockerfile

### DIFF
--- a/Dockerfile.navigation
+++ b/Dockerfile.navigation
@@ -4,11 +4,11 @@ FROM husarion/navigation2:humble-1.1.12-20240123
 RUN set -euo pipefail; \
     rm -f /etc/apt/sources.list.d/ros2.list /etc/apt/sources.list.d/ros2-latest.list; \
     apt-get update; \
-    apt-get install -y --no-install-recommends ca-certificates curl; \
+    apt-get install -y --no-install-recommends ca-certificates curl gnupg; \
     rm -rf /var/lib/apt/lists/*; \
     mkdir -p /usr/share/keyrings; \
-    curl -fsSL https://raw.githubusercontent.com/ros/rosdistro/master/ros-archive-keyring.gpg \
-      -o /usr/share/keyrings/ros-archive-keyring.gpg; \
+    curl -fsSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key \
+      | gpg --batch --yes --dearmor -o /usr/share/keyrings/ros-archive-keyring.gpg; \
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] \
       http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo \"${UBUNTU_CODENAME}\") main" \
       > /etc/apt/sources.list.d/ros2.list


### PR DESCRIPTION
## Summary
- download the ROS repository key from ros.key and dearmor it during the image build
- add gnupg to the navigation image so gpg is available for the key conversion

## Testing
- ⚠️ `docker build -f Dockerfile.navigation --progress=plain .` *(fails: docker is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e7e1707c5483238deb963aa0a00c39