### PR TITLE
Add EKF startup logging and TF readiness check

### DIFF
--- a/scripts/start_navigation_with_ekf.sh
+++ b/scripts/start_navigation_with_ekf.sh
@@ -6,9 +6,20 @@ if [ -f "/ros2_ws/install/setup.bash" ]; then
   source /ros2_ws/install/setup.bash
 fi
 
-ros2 run robot_localization ekf_node --ros-args --params-file /config/ekf.yaml &
+echo "[EKF] Lanzando robot_localization::ekf_node con /config/ekf.yaml ..."
+ros2 run robot_localization ekf_node --ros-args --params-file /config/ekf.yaml >/tmp/ekf.log 2>&1 &
 EKF_PID=$!
 trap 'kill "${EKF_PID}" 2>/dev/null || true' EXIT
+
+sleep 1
+echo "[EKF] Comprobando odom->base_link (hasta 5s)..."
+for i in {1..5}; do
+  if timeout 1 ros2 run tf2_ros tf2_echo odom base_link >/dev/null 2>&1; then
+    echo "[EKF] OK: odom->base_link disponible"
+    break
+  fi
+  sleep 1
+done
 
 ros2 launch /husarion_utils/bringup_launch.py \
   slam:=${SLAM:-True} \


### PR DESCRIPTION
## Summary
- add explicit logging when starting the EKF node
- redirect EKF node output to a temp log file for easier inspection
- perform a short loop to verify the odom->base_link transform becomes available

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e7ec5e4550832383a26e2eca8b8d12