### PR TITLE
Add localization service to docker compose

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -13,6 +13,13 @@ services:
         mecanum:=${MECANUM:-True}
         depthai_params_file:=/config/oak_1080p.yaml
 
+  localization:
+    image: husarion/rosbot-xl:humble
+    container_name: rosbot-localization
+    depends_on:
+      - rosbot
+    command: ros2 launch rosbot_localization ekf.launch.py
+
   microros:
     image: husarion/micro-ros-agent:humble-3.1.3-20240126
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- add a localization service that runs the EKF launch file
- ensure the localization container waits for the rosbot bringup to start

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e8d8fb22648323af79825e396ecb8d