### PR TITLE
Add EKF localization container and configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,25 @@ if your hardware requires a different configuration.
    `planner_frequency` or `progress_timeout` and restart the Compose stack to
    apply the changes.
 
+### 🧭 Sensor fusion and TF availability
+
+The stack now runs a dedicated `localization` container that launches the
+`robot_localization` EKF.  Its parameters live in `config/ekf.yaml`, where we
+fuse wheel odometry velocities with the IMU yaw rate in a 2D filter and publish
+the `odom → base_link` transform required by Nav2.  If you need to tweak the
+fusion weights or topics, edit that YAML file and restart the stack.
+
+To confirm that the transform is available for planners and costmaps, you can
+echo it from any ROS 2 shell (for example inside the `navigation` container):
+
+```bash
+ros2 run tf2_ros tf2_echo odom base_link
+```
+
+You should see the transform updating continuously; if the command times out,
+check that the EKF container is running and that odometry and IMU topics are
+being published with correct frame IDs.
+
 ### 🚗 Step 5: Control the ROSbot from a Web Browser
 
 Open the **Google Chrome** browser on your laptop and navigate to:

--- a/compose.yaml
+++ b/compose.yaml
@@ -14,11 +14,18 @@ services:
         depthai_params_file:=/config/oak_1080p.yaml
 
   localization:
-    image: husarion/rosbot-xl:humble
+    image: husarion/rosbot-xl:humble-0.10.0-20240202
     container_name: rosbot-localization
+    network_mode: host
+    restart: unless-stopped
+    environment: [ ROS_DOMAIN_ID=0 ]
+    volumes:
+      - ./config/ekf.yaml:/config/ekf.yaml:ro
     depends_on:
       - rosbot
-    command: ros2 launch rosbot_localization ekf.launch.py
+    command: >
+      ros2 launch rosbot_localization ekf.launch.py
+        params_file:=/config/ekf.yaml
 
   microros:
     image: husarion/micro-ros-agent:humble-3.1.3-20240126

--- a/config/ekf.yaml
+++ b/config/ekf.yaml
@@ -1,0 +1,27 @@
+ekf_filter_node:
+  ros__parameters:
+    frequency: 30.0
+    two_d_mode: true
+    publish_tf: true
+    use_sim_time: false
+    map_frame: map
+    odom_frame: odom
+    base_link_frame: base_link
+    world_frame: odom
+
+    odom0: /rosbot_xl_base_controller/odom
+    odom0_config: [false, false, false,
+                   false, false, false,
+                   true,  true,  false,
+                   false, false, true,
+                   false, false, false]
+
+    imu0: /imu_broadcaster/imu
+    imu0_config: [false, false, false,
+                  false, false, false,
+                  false, false, false,
+                  false, false, true,
+                  false, false, false]
+
+    imu0_differential: false
+    imu0_remove_gravitational_acceleration: true


### PR DESCRIPTION
## Summary
- add a dedicated localization service to docker compose that launches the robot_localization EKF with a custom parameter file
- provide an EKF configuration that fuses wheel odometry and IMU yaw data while publishing the odom to base_link transform
- document how to verify the localization transform within the README

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e8da1cc2fc8323b9451bf665a0697b