### PR TITLE
Add EKF odom localization service configuration

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -14,18 +14,18 @@ services:
         depthai_params_file:=/config/oak_1080p.yaml
 
   localization:
-    image: husarion/rosbot-xl:humble-0.10.0-20240202
+    image: husarion/rosbot-xl:humble
     container_name: rosbot-localization
-    network_mode: host
-    restart: unless-stopped
-    environment: [ ROS_DOMAIN_ID=0 ]
-    volumes:
-      - ./config/ekf.yaml:/config/ekf.yaml:ro
     depends_on:
       - rosbot
+    environment:
+      - ROS_DOMAIN_ID=${ROS_DOMAIN_ID:-0}
+    volumes:
+      - ./config/ekf_odom.yaml:/config/ekf_odom.yaml:ro
     command: >
-      ros2 launch rosbot_localization ekf.launch.py
-        params_file:=/config/ekf.yaml
+      bash -lc "source /opt/ros/humble/setup.bash &&
+                ros2 run robot_localization ekf_node
+                --ros-args --params-file /config/ekf_odom.yaml"
 
   microros:
     image: husarion/micro-ros-agent:humble-3.1.3-20240126
@@ -51,18 +51,6 @@ services:
       timeout: 5s
       start_period: 90s
       retries: 10
-
-  scan_filter:
-    build:
-      context: .
-      dockerfile: Dockerfile.scan_filter
-    network_mode: host
-    restart: unless-stopped
-    environment: [ ROS_DOMAIN_ID=0 ]
-    volumes:
-      - ./config/laser_filters.yaml:/config/laser_filters.yaml:ro
-    depends_on:
-      - rplidar
 
   navigation:
     image: husarion/navigation2:humble-1.1.12-20240123

--- a/config/ekf_odom.yaml
+++ b/config/ekf_odom.yaml
@@ -1,0 +1,28 @@
+ekf_node:
+  ros__parameters:
+    frequency: 30.0
+    two_d_mode: true
+    publish_tf: true
+
+    map_frame: map
+    odom_frame: odom
+    base_link_frame: base_link
+    world_frame: odom    # <— CLAVE: el EKF publicará odom -> base_link
+
+    # Ajusta estos tópicos si en tu robot son diferentes:
+    odom0: /rosbot_xl_base_controller/odom
+    odom0_config: [false, false, false,
+                   false, false, false,
+                   true,  true,  false,
+                   false, false, true,
+                   false, false, false]
+
+    imu0: /imu_broadcaster/imu
+    imu0_config: [false, false, false,
+                  false, false, false,
+                  false, false, false,
+                  false, false, true,
+                  false, false, false]
+
+    imu0_differential: false
+    imu0_remove_gravitational_acceleration: true

--- a/rosbotxl/config/ekf_odom.yaml
+++ b/rosbotxl/config/ekf_odom.yaml
@@ -1,0 +1,28 @@
+ekf_node:
+  ros__parameters:
+    frequency: 30.0
+    two_d_mode: true
+    publish_tf: true
+
+    map_frame: map
+    odom_frame: odom
+    base_link_frame: base_link
+    world_frame: odom    # <— CLAVE: el EKF publicará odom -> base_link
+
+    # Ajusta estos tópicos si en tu robot son diferentes:
+    odom0: /rosbot_xl_base_controller/odom
+    odom0_config: [false, false, false,
+                   false, false, false,
+                   true,  true,  false,
+                   false, false, true,
+                   false, false, false]
+
+    imu0: /imu_broadcaster/imu
+    imu0_config: [false, false, false,
+                  false, false, false,
+                  false, false, false,
+                  false, false, true,
+                  false, false, false]
+
+    imu0_differential: false
+    imu0_remove_gravitational_acceleration: true


### PR DESCRIPTION
## Summary
- add a dedicated EKF parameter file that publishes the odom to base_link transform
- update the localization service to run robot_localization with the new parameters
- remove the external scan_filter service per the revised container plan

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e8e850c0608323befb82b9cdae6bfb