### PR TITLE
Set unique EKF node identity in localization service

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -25,7 +25,10 @@ services:
     command: >
       bash -lc "source /opt/ros/humble/setup.bash &&
                 ros2 run robot_localization ekf_node
-                --ros-args --params-file /config/ekf_odom.yaml"
+                --ros-args
+                --params-file /config/ekf_odom.yaml
+                -r __node:=ekf_external
+                -r __ns:=/localization"
 
   microros:
     image: husarion/micro-ros-agent:humble-3.1.3-20240126


### PR DESCRIPTION
## Summary
- assign the localization EKF node a dedicated name and namespace to avoid collisions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e8ef9758bc8323b6ce681266d76d77