### PR TITLE
Ensure external EKF exclusively handles odom TF

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,3 +1,4 @@
+version: "3.9"
 services:
 
   rosbot:
@@ -11,21 +12,16 @@ services:
     command: >
       bash -lc '
         set -euo pipefail;
-        # Arranca el bringup en background
-        ros2 launch rosbot_xl_bringup bringup.launch.py
-          mecanum:=${MECANUM:-True}
-          depthai_params_file:=/config/oak_1080p.yaml &
-        LAUNCH_PID=$!;
-        # Espera a que el ekf interno (ekf_node) arranque y mátalo (máx ~10s)
-        for i in $(seq 1 20); do
-          pgrep -x ekf_node >/dev/null && break || sleep 0.5;
-        done
-        pkill -x ekf_node || true;
-        # Asegura que el controlador NO publique odom->base_link
-        until ros2 service list | grep -q "/controller_manager/switch_controller"; do sleep 0.5; done
-        ros2 param set /rosbot_xl_base_controller enable_odom_tf false || true;
-        # Mantén el bringup en foreground
-        wait $LAUNCH_PID
+        # Watchdog: mantén MUERTO el ekf_node interno aunque tenga respawn
+        ( while :; do pkill -x ekf_node >/dev/null 2>&1 || true; sleep 1; done ) &
+        # Desactiva TF del controlador cuando esté listo el controller_manager
+        ( until ros2 service list | grep -q "/controller_manager/switch_controller"; do sleep 0.5; done
+          ros2 param set /rosbot_xl_base_controller enable_odom_tf false || true
+        ) &
+        # Lanza el bringup en foreground (sin variables raras tipo LAUNCH_PID)
+        exec ros2 launch rosbot_xl_bringup bringup.launch.py \
+          mecanum:=${MECANUM:-True} \
+          depthai_params_file:=/config/oak_1080p.yaml
       '
 
   localization:
@@ -33,19 +29,19 @@ services:
     container_name: rosbot-localization
     depends_on:
       - rosbot
+    network_mode: host
+    restart: unless-stopped
     environment:
       - ROS_DOMAIN_ID=${ROS_DOMAIN_ID:-0}
-      # Namespace dedicado para el EKF externo
       - ROS_NAMESPACE=/localization
     volumes:
       - ./config/ekf_odom.yaml:/config/ekf_odom.yaml:ro
     command: >
       bash -lc '
         source /opt/ros/humble/setup.bash;
-        # Nombre único del nodo: /localization/ekf
-        ros2 run robot_localization ekf_node
-          --ros-args
-          --params-file /config/ekf_odom.yaml
+        exec ros2 run robot_localization ekf_node \
+          --ros-args \
+          --params-file /config/ekf_odom.yaml \
           -r __node:=ekf
       '
 

--- a/config/ekf_odom.yaml
+++ b/config/ekf_odom.yaml
@@ -1,4 +1,33 @@
-ekf_node:
+ekf:
+  ros__parameters:
+    frequency: 30.0
+    two_d_mode: true
+    publish_tf: true
+
+    map_frame: map
+    odom_frame: odom
+    base_link_frame: base_link
+    world_frame: odom    # <— CLAVE: el EKF publicará odom -> base_link
+
+    # Ajusta estos tópicos si en tu robot son diferentes:
+    odom0: /rosbot_xl_base_controller/odom
+    odom0_config: [false, false, false,
+                   false, false, false,
+                   true,  true,  false,
+                   false, false, true,
+                   false, false, false]
+
+    imu0: /imu_broadcaster/imu
+    imu0_config: [false, false, false,
+                  false, false, false,
+                  false, false, false,
+                  false, false, true,
+                  false, false, false]
+
+    imu0_differential: false
+    imu0_remove_gravitational_acceleration: true
+
+ekf_filter_node:
   ros__parameters:
     frequency: 30.0
     two_d_mode: true


### PR DESCRIPTION
## Summary
- update the rosbot launch command to keep the internal ekf_node terminated and disable base controller TF publishing
- run the external localization container in host networking with a fixed namespace and node name
- provide EKF parameters for both `ekf` and `ekf_filter_node` node names

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ee29def23c83239ccca529c8f400f9