### PR TITLE
Harden ekf watchdog and keep compose command

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -13,7 +13,12 @@ services:
       bash -lc '
         set -euo pipefail;
         # Watchdog: mantén MUERTO el ekf_node interno aunque tenga respawn
-        ( while :; do pkill -x ekf_node >/dev/null 2>&1 || true; sleep 1; done ) &
+        ( while :; do
+            pkill -x ekf_node >/dev/null 2>&1 \
+            || pkill -f "/robot_localization/ekf_node" >/dev/null 2>&1 \
+            || true;
+            sleep 1;
+          done ) &
         # Desactiva TF del controlador cuando esté listo el controller_manager
         ( until ros2 service list | grep -q "/controller_manager/switch_controller"; do sleep 0.5; done
           ros2 param set /rosbot_xl_base_controller enable_odom_tf false || true

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -13,10 +13,7 @@ services:
     volumes:
       - ./maps:/maps
       - ./config/oak_1080p.yaml:/config/oak_1080p.yaml:ro
-    command: >
-      ros2 launch rosbot_xl_bringup bringup.launch.py
-        mecanum:=${MECANUM:-True}
-        depthai_params_file:=/config/oak_1080p.yaml
+    # No sobreescribas el command aquí: dejamos el watchdog definido en compose.yaml
 
   ###############################################################
   # 2) teleop_twist_keyboard (mover el robot)


### PR DESCRIPTION
## Summary
- extend the rosbot watchdog loop to kill ekf_node processes by name or full path
- stop overriding the rosbot command in the override compose file so the watchdog remains active

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ee3571e4588323b54706f2d8a11739