### PR TITLE
Scope EKF node namespace via ros2 remapping

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -38,7 +38,6 @@ services:
     restart: unless-stopped
     environment:
       - ROS_DOMAIN_ID=${ROS_DOMAIN_ID:-0}
-      - ROS_NAMESPACE=/localization
     volumes:
       - ./config/ekf_odom.yaml:/config/ekf_odom.yaml:ro
     command: >
@@ -46,8 +45,8 @@ services:
         source /opt/ros/humble/setup.bash;
         exec ros2 run robot_localization ekf_node \
           --ros-args \
-          --params-file /config/ekf_odom.yaml \
-          -r __node:=ekf
+          -r __node:=ekf -r __ns:=/localization \
+          --params-file /config/ekf_odom.yaml
       '
 
   microros:

--- a/config/ekf_odom.yaml
+++ b/config/ekf_odom.yaml
@@ -1,57 +1,35 @@
-ekf:
+/localization/ekf:
   ros__parameters:
+    # Frecuencia de fusión
     frequency: 30.0
     two_d_mode: true
-    publish_tf: true
+    use_sim_time: false
 
+    # Publicación de TF
+    publish_tf: true
     map_frame: map
     odom_frame: odom
     base_link_frame: base_link
-    world_frame: odom    # <— CLAVE: el EKF publicará odom -> base_link
+    world_frame: odom            # ⇒ EKF publica odom -> base_link
 
-    # Ajusta estos tópicos si en tu robot son diferentes:
+    # Odometría de ruedas
     odom0: /rosbot_xl_base_controller/odom
-    odom0_config: [false, false, false,
-                   false, false, false,
-                   true,  true,  false,
-                   false, false, true,
-                   false, false, false]
+    odom0_config: [
+      false, false, false,
+      false, false, false,
+      true,  true,  false,
+      false, false, true,
+      false, false, false
+    ]
 
+    # IMU (yaw)
     imu0: /imu_broadcaster/imu
-    imu0_config: [false, false, false,
-                  false, false, false,
-                  false, false, false,
-                  false, false, true,
-                  false, false, false]
-
-    imu0_differential: false
-    imu0_remove_gravitational_acceleration: true
-
-ekf_filter_node:
-  ros__parameters:
-    frequency: 30.0
-    two_d_mode: true
-    publish_tf: true
-
-    map_frame: map
-    odom_frame: odom
-    base_link_frame: base_link
-    world_frame: odom    # <— CLAVE: el EKF publicará odom -> base_link
-
-    # Ajusta estos tópicos si en tu robot son diferentes:
-    odom0: /rosbot_xl_base_controller/odom
-    odom0_config: [false, false, false,
-                   false, false, false,
-                   true,  true,  false,
-                   false, false, true,
-                   false, false, false]
-
-    imu0: /imu_broadcaster/imu
-    imu0_config: [false, false, false,
-                  false, false, false,
-                  false, false, false,
-                  false, false, true,
-                  false, false, false]
-
+    imu0_config: [
+      false, false, false,
+      false, false, false,
+      false, false, false,
+      false, false, true,
+      false, false, false
+    ]
     imu0_differential: false
     imu0_remove_gravitational_acceleration: true


### PR DESCRIPTION
## Summary
- remap the ekf_node namespace using ros2 arguments instead of ROS_NAMESPACE
- update the ekf parameters file to use the fully qualified /localization/ekf node block

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ee3649f8e08323a197ad517bae7e32