### PR TITLE
Disable internal EKF TF and mount override config

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -9,16 +9,10 @@ services:
     environment: [ ROS_DOMAIN_ID=0 ]
     volumes:
       - ./config/oak_1080p.yaml:/config/oak_1080p.yaml:ro
+      - ./config/ekf_internal_off.yaml:/ros2_ws/install/rosbot_xl_bringup/share/rosbot_xl_bringup/config/ekf.yaml:ro
     command: >
       bash -lc '
         set -euo pipefail;
-        # Watchdog: mantén MUERTO el ekf_node interno aunque tenga respawn
-        ( while :; do
-            pkill -x ekf_node >/dev/null 2>&1 \
-            || pkill -f "/robot_localization/ekf_node" >/dev/null 2>&1 \
-            || true;
-            sleep 1;
-          done ) &
         # Desactiva TF del controlador cuando esté listo el controller_manager
         ( until ros2 service list | grep -q "/controller_manager/switch_controller"; do sleep 0.5; done
           ros2 param set /rosbot_xl_base_controller enable_odom_tf false || true

--- a/config/ekf_internal_off.yaml
+++ b/config/ekf_internal_off.yaml
@@ -1,0 +1,27 @@
+# config/ekf_internal_off.yaml
+ekf_filter_node:
+  ros__parameters:
+    publish_tf: false         # ← lo importante: NO publica TF
+    two_d_mode: true
+    use_sim_time: false
+    map_frame: map
+    odom_frame: odom
+    base_link_frame: base_link
+    world_frame: odom
+
+    odom0: /rosbot_xl_base_controller/odom
+    odom0_config: [false, false, false,
+                   false, false, false,
+                   true,  true,  false,
+                   false, false, true,
+                   false, false, false]
+
+    imu0: /imu_broadcaster/imu
+    imu0_config: [false, false, false,
+                  false, false, false,
+                  false, false, false,
+                  false, false, true,
+                  false, false, false]
+
+    imu0_differential: false
+    imu0_remove_gravitational_acceleration: true


### PR DESCRIPTION
## Summary
- add an EKF configuration override file that disables TF publishing for the internal robot_localization instance
- mount the override into the rosbot container and rely on the external localization EKF

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ee3c6195808323849cacce01410c17