### PR TITLE
Fix rosbot bringup wait syntax and align RMW settings

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -47,7 +47,7 @@ services:
           sleep 0.5
         done
 
-        wait ${BRINGUP_PID}
+        wait $BRINGUP_PID
       '
     healthcheck:
       test: ["CMD-SHELL",
@@ -67,7 +67,8 @@ services:
     network_mode: host
     restart: unless-stopped
     environment:
-      - ROS_DOMAIN_ID=${ROS_DOMAIN_ID:-0}
+      - ROS_DOMAIN_ID=0
+      - RMW_IMPLEMENTATION=rmw_fastrtps_cpp
     init: true
     entrypoint: ["/bin/bash", "/entrypoint.sh"]
     volumes:

--- a/override-rosbot.yml
+++ b/override-rosbot.yml
@@ -6,25 +6,20 @@ services:
       - AMENT_TRACE_SETUP_FILES=
     command: >
       bash -lc '
-        # 1) Carga entorno ROS (sin set -u para evitar "unbound variable")
+        set -x
         source /opt/ros/humble/setup.bash;
 
-        # 2) Lanza el bringup en background
         ros2 launch rosbot_xl_bringup bringup.launch.py \
           mecanum:=$${MECANUM:-True} \
           depthai_params_file:=/config/oak_1080p.yaml &
-        LAUNCH_PID=$!;
+        LAUNCH_PID=$!
 
-        # 3) Espera a controller_manager y spawnea controladores
         until ros2 service list | grep -q "/controller_manager/switch_controller"; do sleep 0.5; done
-        ros2 run controller_manager spawner joint_state_broadcaster \
-            -c /controller_manager --controller-manager-timeout 20 || true
-        ros2 run controller_manager spawner rosbot_xl_base_controller \
-            -c /controller_manager --controller-manager-timeout 20 || true
 
-        # 4) Desactiva la TF del controlador (queremos que la publique SOLO el EKF)
+        ros2 run controller_manager spawner joint_state_broadcaster -c /controller_manager --controller-manager-timeout 20
+        ros2 run controller_manager spawner rosbot_xl_base_controller -c /controller_manager --controller-manager-timeout 20
+
         ros2 param set /rosbot_xl_base_controller enable_odom_tf false || true
 
-        # 5) Mantén el contenedor vivo
         wait $LAUNCH_PID
       '


### PR DESCRIPTION
## Summary
- correct the shell wait command in compose.yaml so it receives the bringup PID properly
- enable verbose launch and stricter spawner handling in override-rosbot.yml
- align localization container ROS domain and RMW implementation with the rosbot service

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ee7394e9148323b877200bd898c111