### PR TITLE
Fix teleop recipe attach command

### DIFF
--- a/justfile
+++ b/justfile
@@ -151,7 +151,12 @@ teleop:
     @echo "│          A/D = girar;  Q/E = giro suave"
     @echo "│  Salir sin matar:  Ctrl-P  Ctrl-Q"
     @echo "╰───────────────────────────────────────────"
-    docker attach $$(docker compose -f compose.yaml -f docker-compose.override.yml ps -q teleop)
+    @container_id=$$(docker compose -f compose.yaml -f docker-compose.override.yml ps -q teleop)
+    @if [ -z "$$container_id" ]; then \
+        echo "⛔  contenedor 'teleop' no está en ejecución"; \
+        exit 1; \
+    fi
+    docker attach $$container_id
 
 # ------------------ Rutas grabadas ---------------------------------
 


### PR DESCRIPTION
## Summary
- ensure the teleop recipe retrieves the container id without causing shell substitution errors
- add a friendly error message when the teleop container is not running before attaching

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ee7f7a2e54832392c9f73e3fd27e02