### PR TITLE
Restore teleop recipe to pre-ekf update behavior

### DIFF
--- a/justfile
+++ b/justfile
@@ -142,27 +142,15 @@ _install-yq:
     fi
 
 teleop:
-    #!/bin/bash
-    set -euo pipefail
-
-    echo "Starting sensors + SLAM + teleop…"
-    docker compose -f compose.yaml -f docker-compose.override.yml up -d \
-        rosbot rplidar navigation teleop foxglove foxglove-ds path_tools
-
-    echo
-    echo "╭───────────────────────────────────────────"
-    echo "│  TELEOP  (W/S = adelante/atrás)"
-    echo "│          A/D = girar;  Q/E = giro suave"
-    echo "│  Salir sin matar:  Ctrl-P  Ctrl-Q"
-    echo "╰───────────────────────────────────────────"
-
-    container_id=$(docker compose -f compose.yaml -f docker-compose.override.yml ps -q teleop)
-    if [[ -z "${container_id}" ]]; then
-        echo "⛔  contenedor 'teleop' no está en ejecución"
-        exit 1
-    fi
-
-    docker attach "${container_id}"
+    @echo "Starting sensors + SLAM + teleop…"
+    docker compose -f compose.yaml -f docker-compose.override.yml up -d
+    @echo ""
+    @echo "╭───────────────────────────────────────────"
+    @echo "│  TELEOP  (W/S = adelante/atrás)"
+    @echo "│          A/D = girar;  Q/E = giro suave"
+    @echo "│  Salir sin matar:  Ctrl-P  Ctrl-Q"
+    @echo "╰───────────────────────────────────────────"
+    docker attach $(docker compose -f compose.yaml -f docker-compose.override.yml ps -q teleop)
 
 # ------------------ Rutas grabadas ---------------------------------
 


### PR DESCRIPTION
## Summary
- revert the `just teleop` recipe to the original flow prior to the EKF service update
- drop the additional bash wrapper and service list so teleop behaves as before

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ee834b2ffc8323b3a68e109d4a99c9