### PR TITLE
Add profile to disable localization service by default

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -14,6 +14,7 @@ services:
         depthai_params_file:=/config/oak_1080p.yaml
 
   localization:
+    profiles: ["ekf-external"]
     image: husarion/rosbot-xl:humble
     container_name: rosbot-localization
     depends_on:


### PR DESCRIPTION
## Summary
- add an ekf-external profile to the localization service so it does not start during default compose runs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ef9a59a1608323aef83dcff4a62531