### PR TITLE
Configure navigation to use DWB controller by default

### DIFF
--- a/.env
+++ b/.env
@@ -36,7 +36,7 @@ SAVE_MAP_PERIOD=15
 # - dwb - DWB controller
 # - rpp - Regulated Pure Pursuit
 # - mppi - Model Predictive Path Integral
-CONTROLLER=mppi
+CONTROLLER=dwb
 
 # =======================================
 # Namespace / Husarnet config

--- a/compose.yaml
+++ b/compose.yaml
@@ -63,7 +63,7 @@ services:
       rplidar: { condition: service_started }
       rosbot:  { condition: service_started }
     volumes:
-      - ./config/nav2_${CONTROLLER:-mppi}_params.yaml:/params.yaml
+      - ./config/nav2_${CONTROLLER:-rpp}_params.yaml:/params.yaml
       - ./maps:/maps
       - ./scripts:/ros2_ws/scripts:ro
     environment:


### PR DESCRIPTION
## Summary
- set the default Nav2 controller to DWB via the .env configuration
- adjust docker compose to fall back to Regulated Pure Pursuit parameters when no controller is specified

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68efb3e88a8483238b8fd002b9a2c7c3