### PR TITLE
Adjust Nav2 AMCL and DWB persistent tuning

### DIFF
--- a/config/nav2_dwb_params.yaml
+++ b/config/nav2_dwb_params.yaml
@@ -10,8 +10,8 @@ amcl:
 
     robot_model_type: nav2_amcl::DifferentialMotionModel
 
-    set_initial_pose: true
-    always_reset_initial_pose: true
+    set_initial_pose: false
+    always_reset_initial_pose: false
 
     tf_broadcast: true
     transform_tolerance: 0.30
@@ -143,7 +143,7 @@ bt_navigator_navigate_to_pose_rclcpp_node:
 controller_server:
   ros__parameters:
     use_sim_time: false
-    controller_frequency: 5.0
+    controller_frequency: 15.0
     min_x_velocity_threshold: 0.001
     min_y_velocity_threshold: 0.5
     min_theta_velocity_threshold: 0.001
@@ -166,8 +166,8 @@ controller_server:
     general_goal_checker:
       stateful: true
       plugin: nav2_controller::SimpleGoalChecker
-      xy_goal_tolerance: 0.50
-      yaw_goal_tolerance: 0.60
+      xy_goal_tolerance: 0.10
+      yaw_goal_tolerance: 0.25
     # DWB parameters
     FollowPath:
       plugin: dwb_core::DWBLocalPlanner
@@ -200,7 +200,7 @@ controller_server:
       short_circuit_trajectory_evaluation: true
       stateful: true
       critics: [RotateToGoal, Oscillation, BaseObstacle, GoalAlign, PathAlign, PathDist, GoalDist]
-      BaseObstacle.scale: 0.02
+      BaseObstacle.scale: 0.10
       PathAlign.scale: 32.0
       PathAlign.forward_point_distance: 0.1
       GoalAlign.scale: 24.0
@@ -244,8 +244,8 @@ local_costmap:
       inflation_layer:
         plugin: nav2_costmap_2d::InflationLayer
         enabled: true
-        inflation_radius: 0.10
-        cost_scaling_factor: 7.5
+        inflation_radius: 0.30
+        cost_scaling_factor: 5.0
 
       always_send_full_costmap: true
 

--- a/config/nav2_dwb_webots_params.yaml
+++ b/config/nav2_dwb_webots_params.yaml
@@ -10,8 +10,8 @@ amcl:
 
     robot_model_type: nav2_amcl::DifferentialMotionModel
 
-    set_initial_pose: true
-    always_reset_initial_pose: true
+    set_initial_pose: false
+    always_reset_initial_pose: false
 
     tf_broadcast: true
     transform_tolerance: 1.0
@@ -143,7 +143,7 @@ bt_navigator_navigate_to_pose_rclcpp_node:
 controller_server:
   ros__parameters:
     use_sim_time: false
-    controller_frequency: 5.0
+    controller_frequency: 15.0
     min_x_velocity_threshold: 0.001
     min_y_velocity_threshold: 0.5
     min_theta_velocity_threshold: 0.001
@@ -166,8 +166,8 @@ controller_server:
     general_goal_checker:
       stateful: true
       plugin: nav2_controller::SimpleGoalChecker
-      xy_goal_tolerance: 0.2
-      yaw_goal_tolerance: 0.2
+      xy_goal_tolerance: 0.10
+      yaw_goal_tolerance: 0.25
     # DWB parameters
     FollowPath:
       plugin: dwb_core::DWBLocalPlanner
@@ -200,7 +200,7 @@ controller_server:
       short_circuit_trajectory_evaluation: true
       stateful: true
       critics: [RotateToGoal, Oscillation, BaseObstacle, GoalAlign, PathAlign, PathDist, GoalDist]
-      BaseObstacle.scale: 0.02
+      BaseObstacle.scale: 0.10
       PathAlign.scale: 32.0
       PathAlign.forward_point_distance: 0.1
       GoalAlign.scale: 24.0
@@ -245,8 +245,8 @@ local_costmap:
           max_obstacle_height: 2.0
       inflation_layer:
         plugin: nav2_costmap_2d::InflationLayer
-        cost_scaling_factor: 3.0
-        inflation_radius: 0.55
+        cost_scaling_factor: 5.0
+        inflation_radius: 0.30
 
       always_send_full_costmap: true
 


### PR DESCRIPTION
## Summary
- disable AMCL automatic pose reset in both Nav2 configs
- raise controller frequency and tighten goal tolerances for DWB
- persist updated BaseObstacle scale and local costmap inflation parameters

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68efbb6262bc8323aebf6892151bfb1d