### PR TITLE
Set default DWB navigation defaults

### DIFF
--- a/.env
+++ b/.env
@@ -24,10 +24,10 @@ MECANUM=False
 # Select SLAM mode (to load map place the `map.yaml` and `map.png` file in the `./maps` path):
 # - True - with mapping
 # - False - without mapping
-SLAM=True
+SLAM=False
 
 # Default map used by navigation
-MAP=r1
+MAP=test1
 
 # Period of time for autosave map. Work only when SLAM=True (set 0 to disable)
 SAVE_MAP_PERIOD=15


### PR DESCRIPTION
## Summary
- disable SLAM by default so docker compose loads navigation params instead of mapping
- set the default map to `test1` to align with the DWB configuration

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68efc40b288c832386f55b223612a1a4