### PR TITLE
Revert patch yaml configuration update scripts

### DIFF
--- a/config/nav2_dwb_params.yaml
+++ b/config/nav2_dwb_params.yaml
@@ -244,8 +244,8 @@ local_costmap:
       inflation_layer:
         plugin: nav2_costmap_2d::InflationLayer
         enabled: true
-        inflation_radius: 0.25
-        cost_scaling_factor: 2.5
+        inflation_radius: 0.10
+        cost_scaling_factor: 7.5
 
       always_send_full_costmap: true
 
@@ -262,13 +262,13 @@ global_costmap:
       footprint_padding: 0.005
       resolution: 0.05
       track_unknown_space: true
-      plugins: [static_layer, inflation_layer]
+      plugins: [static_layer, obstacle_layer, inflation_layer]
       static_layer:
         plugin: nav2_costmap_2d::StaticLayer
         map_subscribe_transient_local: true
       obstacle_layer:
         plugin: nav2_costmap_2d::ObstacleLayer
-        enabled: false
+        enabled: true
         footprint_clearing_enabled: true
         observation_sources: scan
         scan:
@@ -283,8 +283,8 @@ global_costmap:
       inflation_layer:
         plugin: nav2_costmap_2d::InflationLayer
         enabled: true
-        inflation_radius: 0.20
-        cost_scaling_factor: 3.0
+        inflation_radius: 0.10
+        cost_scaling_factor: 7.5
       always_send_full_costmap: true
 
 map_server:

--- a/config/nav2_mppi_params.yaml
+++ b/config/nav2_mppi_params.yaml
@@ -218,16 +218,16 @@ local_costmap:
           marking: true
           clearing: true
           inf_is_valid: true
-          obstacle_range: 5.0
-          raytrace_range: 6.0
-          observation_persistence: 0.0
+          obstacle_range: 6.5
+          raytrace_range: 8.0
+          observation_persistence: 0.40
       inflation_layer:
         plugin: nav2_costmap_2d::InflationLayer
         enabled: true
-        inflation_radius: 0.25
-        cost_scaling_factor: 2.5
+        inflation_radius: 0.22
+        cost_scaling_factor: 3.0
       robot_radius: 0.18
-      footprint_padding: 0.005
+      footprint_padding: 0.05
 
       always_send_full_costmap: true
 
@@ -249,14 +249,14 @@ global_costmap:
       transform_tolerance: 0.30
       resolution: 0.05
       track_unknown_space: true
-      plugins: [static_layer, inflation_layer]
+      plugins: [static_layer, obstacle_layer, inflation_layer]
       static_layer:
         plugin: nav2_costmap_2d::StaticLayer
         enabled: true
         map_subscribe_transient_local: true
       obstacle_layer:
         plugin: nav2_costmap_2d::ObstacleLayer
-        enabled: false
+        enabled: true
         footprint_clearing_enabled: true
         observation_sources: scan
         scan:
@@ -267,14 +267,15 @@ global_costmap:
           inf_is_valid: true
           obstacle_range: 5.0
           raytrace_range: 6.0
-          observation_persistence: 0.0
+          observation_persistence: 0.35
       inflation_layer:
         plugin: nav2_costmap_2d::InflationLayer
         enabled: true
-        inflation_radius: 0.20
+        inflation_radius: 0.35
         cost_scaling_factor: 3.0
-      robot_radius: 0.18
-      footprint_padding: 0.005
+      footprint: '[[0.165, 0.145], [0.165, -0.145], [-0.165, -0.145], [-0.165, 0.145]]'
+      robot_radius: 0.0
+      footprint_padding: 0.02
       always_send_full_costmap: true
   global_costmap_client:
     ros__parameters:

--- a/justfile
+++ b/justfile
@@ -175,8 +175,7 @@ play-ntp name:
     docker exec -it $(docker compose ps -q path_tools) \
         bash -c "source /opt/ros/humble/setup.bash && \
                  python3 /scripts/nav_through_poses.py \
-                 --file /routes/{{name}}.yaml \
-                 --set-initialpose first"
+                 --file /routes/{{name}}.yaml"
 # ────────────────────────────────────────────────────────────────
 #  start-route  →  Arranca ROSbot con mapa fijo y reproduce una ruta
 #     Uso:  just start-route mi_ruta        # (omite la extensión .yaml)

--- a/scripts/nav_through_poses.py
+++ b/scripts/nav_through_poses.py
@@ -2,7 +2,7 @@
 import sys, math, yaml, rclpy, signal
 from rclpy.node import Node
 from rclpy.action import ActionClient
-from geometry_msgs.msg import PoseStamped, Quaternion, PoseWithCovarianceStamped
+from geometry_msgs.msg import PoseStamped, Quaternion
 from builtin_interfaces.msg import Time as TimeMsg
 from nav2_msgs.action import NavigateThroughPoses
 
@@ -13,15 +13,12 @@ def q_from_yaw(yaw: float):
 
 
 class NTPClient(Node):
-    def __init__(self, yaml_file: str, frame_id: str = "map", set_initialpose: str = "none"):
+    def __init__(self, yaml_file: str, frame_id: str = "map"):
         super().__init__("nav_through_poses_client")
         self._shutdown_called = False
         self._ac = ActionClient(self, NavigateThroughPoses, "/navigate_through_poses")
         self._poses = self._load_yaml(yaml_file, frame_id)
-        self._init_pub = self.create_publisher(PoseWithCovarianceStamped, "/initialpose", 1)
-        self._set_initialpose = set_initialpose
         self.get_logger().info(f"Leyendo {yaml_file} – {len(self._poses)} puntos (NTP)")
-        self._maybe_publish_initialpose()
         self._send_goal()
 
     def _load_yaml(self, path, frame_id):
@@ -39,23 +36,6 @@ class NTPClient(Node):
         if not poses:
             raise RuntimeError("El YAML no contiene 'waypoints'.")
         return poses
-
-    def _publish_initialpose(self, ps: PoseStamped):
-        m = PoseWithCovarianceStamped()
-        m.header.frame_id = ps.header.frame_id
-        m.header.stamp = self.get_clock().now().to_msg()
-        m.pose.pose = ps.pose
-        m.pose.covariance[0] = 0.25
-        m.pose.covariance[7] = 0.25
-        m.pose.covariance[35] = 0.12
-        self._init_pub.publish(m)
-        self.get_logger().info("📍  initialpose publicado")
-
-    def _maybe_publish_initialpose(self):
-        if self._set_initialpose == "first":
-            self._publish_initialpose(self._poses[0])
-        elif self._set_initialpose == "zero":
-            self._publish_initialpose(self._mk_pose(self._poses[0].header.frame_id, 0.0, 0.0, 0.0))
 
     def _send_goal(self):
         self.get_logger().info("🚀  Esperando servidor /navigate_through_poses …")
@@ -94,16 +74,6 @@ class NTPClient(Node):
             )
         )
 
-    @staticmethod
-    def _mk_pose(frame_id, x, y, yaw):
-        ps = PoseStamped()
-        ps.header.frame_id = frame_id
-        ps.pose.position.x = float(x)
-        ps.pose.position.y = float(y)
-        q = q_from_yaw(float(yaw))
-        ps.pose.orientation = Quaternion(x=q[0], y=q[1], z=q[2], w=q[3])
-        return ps
-
     def _safe_shutdown(self):
         if self._shutdown_called:
             return
@@ -117,7 +87,7 @@ class NTPClient(Node):
 def main():
     if "--file" not in sys.argv:
         print(
-            "Uso: nav_through_poses.py --file /routes/mi_ruta.yaml [--frame map] [--set-initialpose first|zero|none]",
+            "Uso: nav_through_poses.py --file /routes/mi_ruta.yaml [--frame map]",
             file=sys.stderr,
         )
         sys.exit(1)
@@ -125,14 +95,8 @@ def main():
     frame = "map"
     if "--frame" in sys.argv:
         frame = sys.argv[sys.argv.index("--frame") + 1]
-    set_ip = "none"
-    if "--set-initialpose" in sys.argv:
-        set_ip = sys.argv[sys.argv.index("--set-initialpose") + 1]
-        if set_ip not in ("first", "zero", "none"):
-            print("--set-initialpose debe ser first|zero|none", file=sys.stderr)
-            sys.exit(2)
     rclpy.init()
-    node = NTPClient(yaml_file, frame, set_ip)
+    node = NTPClient(yaml_file, frame)
     # Ctrl-C → cancelación limpia sin 'double shutdown'
     signal.signal(signal.SIGINT, lambda *_: node._safe_shutdown())
     try:


### PR DESCRIPTION
## Summary
- revert the merge of patch yaml configurations and update scripts to restore the previous costmap parameters and navigation script behavior

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f1386178b08323b7ed84745987ccd7