### PR TITLE
Adjust costmap inflation for narrow doorway navigation

### DIFF
--- a/config/nav2_dwb_params.yaml
+++ b/config/nav2_dwb_params.yaml
@@ -244,7 +244,7 @@ local_costmap:
       inflation_layer:
         plugin: nav2_costmap_2d::InflationLayer
         enabled: true
-        inflation_radius: 0.12
+        inflation_radius: 0.10
         cost_scaling_factor: 8.0
 
       always_send_full_costmap: true
@@ -283,7 +283,7 @@ global_costmap:
       inflation_layer:
         plugin: nav2_costmap_2d::InflationLayer
         enabled: true
-        inflation_radius: 0.14
+        inflation_radius: 0.12
         cost_scaling_factor: 10.0
       always_send_full_costmap: true
 

--- a/config/nav2_mppi_params.yaml
+++ b/config/nav2_mppi_params.yaml
@@ -224,7 +224,7 @@ local_costmap:
       inflation_layer:
         plugin: nav2_costmap_2d::InflationLayer
         enabled: true
-        inflation_radius: 0.12
+        inflation_radius: 0.10
         cost_scaling_factor: 8.0
       robot_radius: 0.18
       footprint_padding: 0.005
@@ -271,11 +271,11 @@ global_costmap:
       inflation_layer:
         plugin: nav2_costmap_2d::InflationLayer
         enabled: true
-        inflation_radius: 0.14
+        inflation_radius: 0.12
         cost_scaling_factor: 10.0
       footprint: '[[0.165, 0.145], [0.165, -0.145], [-0.165, -0.145], [-0.165, 0.145]]'
       robot_radius: 0.0
-      footprint_padding: 0.02
+      footprint_padding: 0.005
       always_send_full_costmap: true
   global_costmap_client:
     ros__parameters:


### PR DESCRIPTION
## Summary
- shrink local and global costmap inflation radii for MPPI to better fit 60 cm passages
- apply matching inflation tuning to the DWB costmap configuration
- reduce MPPI global costmap footprint padding to remove artificial widening

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f20caa5ec88323936d9b4adb6c999f