### PR TITLE
Configure BT navigator to use EKF odometry

### DIFF
--- a/config/nav2_mppi_params.yaml
+++ b/config/nav2_mppi_params.yaml
@@ -77,7 +77,7 @@ bt_navigator:
     use_sim_time: false
     global_frame: map
     robot_base_frame: base_link
-    # odom_topic: odom
+    odom_topic: /odometry/filtered
     bt_loop_duration: 10
     default_server_timeout: 20
     wait_for_service_timeout: 1000


### PR DESCRIPTION
## Summary
- configure the behavior tree navigator to subscribe to the EKF filtered odometry topic

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f26a7a07ac8323b08c111d8b1e5828