### PR TITLE
Tune MPPI controller parameters

### DIFF
--- a/config/nav2_mppi_params.yaml
+++ b/config/nav2_mppi_params.yaml
@@ -129,8 +129,8 @@ controller_server:
     goal_checker_plugin: goal_checker
     general_goal_checker:
       plugin: "nav2_controller::SimpleGoalChecker"
-      xy_goal_tolerance: 0.35
-      yaw_goal_tolerance: 0.35
+      xy_goal_tolerance: 0.10
+      yaw_goal_tolerance: 0.25
       stateful: false
     controller_plugins: [FollowPath]
 
@@ -143,8 +143,8 @@ controller_server:
     # Goal checker parameters
     goal_checker:
       plugin: nav2_controller::SimpleGoalChecker
-      xy_goal_tolerance: 0.35
-      yaw_goal_tolerance: 0.35
+      xy_goal_tolerance: 0.10
+      yaw_goal_tolerance: 0.25
       stateful: false
 
     # MPPI controller
@@ -155,15 +155,15 @@ controller_server:
       batch_size: 800
       vx_std: 0.2
       vy_std: 0.0
-      wz_std: 0.60
-      vx_max: 0.25                 # menos “empuje” al entrar en el giro
+      wz_std: 0.50
+      vx_max: 0.30
       vx_min: -0.05                # permite micro‑retroceso para pivotar
       vy_max: 0.0
       wz_max: 1.2            # más autoridad de giro
       iteration_count: 2     # mejora la calidad del control
-      prune_distance: 1.0          # conserva más puntos cercanos al giro
+      prune_distance: 0.8          # conserva más puntos cercanos al giro
       transform_tolerance: 0.25
-      temperature: 0.3
+      temperature: 0.25
       gamma: 0.015
       motion_model: DiffDrive
       visualize: false
@@ -183,12 +183,12 @@ controller_server:
         consider_footprint: true
         collision_margin_distance: 0.10   # margen realista en esquinas
 
-      PathAlignCritic:   {weight: 16.0}   # entra antes a orientar el rumbo
-      PathFollowCritic:  {weight: 5.0}
-      GoalCritic:        {weight: 4.0}
-      PreferForwardCritic: {weight: 3.0}
-      ConstraintCritic:  {weight: 1.0}
-      TwirlingCritic:    {weight: 0.5}    # permite pivotar, sin sobre‑girar
+      PathAlignCritic:     {weight: 12.0}
+      PathFollowCritic:    {weight: 16.0}
+      GoalCritic:          {weight: 1.0}
+      PreferForwardCritic: {weight: 0.5}
+      ConstraintCritic:    {weight: 1.0}
+      TwirlingCritic:      {weight: 0.4}
 
 controller_server_rclcpp_node:
   ros__parameters:


### PR DESCRIPTION
## Summary
- tighten the goal checker tolerances to ensure waypoints are actually reached
- retune MPPI velocity limits, pruning distance, and temperature for closer path tracking
- rebalance MPPI critic weights to prioritize path adherence over goal shortcuts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f762d0a5848323849e0e6b059789c8