### PR TITLE
Revert MPPI and velocity smoother tuning

### DIFF
--- a/config/nav2_mppi_params.yaml
+++ b/config/nav2_mppi_params.yaml
@@ -88,7 +88,6 @@ bt_navigator:
     navigate_through_poses:
       plugin: nav2_bt_navigator/NavigateThroughPosesNavigator
     plugin_lib_names:
-      - nav2_smooth_path_action_bt_node
       - nav2_compute_path_to_pose_action_bt_node
       - nav2_follow_path_action_bt_node
       - nav2_back_up_action_bt_node
@@ -121,16 +120,16 @@ bt_navigator_rclcpp_node:
 controller_server:
   ros__parameters:
     use_sim_time: false
-    controller_frequency: 30.0
+    controller_frequency: 20.0
     min_x_velocity_threshold: 0.01    # Measured
     min_y_velocity_threshold: 0.01    # Measured
-    min_theta_velocity_threshold: 0.02
+    min_theta_velocity_threshold: 0.1 # Measured
     progress_checker_plugin: progress_checker
     goal_checker_plugin: goal_checker
     general_goal_checker:
       plugin: "nav2_controller::SimpleGoalChecker"
-      xy_goal_tolerance: 0.10
-      yaw_goal_tolerance: 0.25
+      xy_goal_tolerance: 0.35
+      yaw_goal_tolerance: 0.35
       stateful: false
     controller_plugins: [FollowPath]
 
@@ -143,8 +142,8 @@ controller_server:
     # Goal checker parameters
     goal_checker:
       plugin: nav2_controller::SimpleGoalChecker
-      xy_goal_tolerance: 0.10
-      yaw_goal_tolerance: 0.25
+      xy_goal_tolerance: 0.35
+      yaw_goal_tolerance: 0.35
       stateful: false
 
     # MPPI controller
@@ -155,15 +154,15 @@ controller_server:
       batch_size: 800
       vx_std: 0.2
       vy_std: 0.0
-      wz_std: 0.50
-      vx_max: 0.30
-      vx_min: -0.05                # permite micro‑retroceso para pivotar
+      wz_std: 0.35
+      vx_max: 0.3
+      vx_min: -0.2
       vy_max: 0.0
-      wz_max: 1.2            # más autoridad de giro
-      iteration_count: 2     # mejora la calidad del control
-      prune_distance: 0.8          # conserva más puntos cercanos al giro
+      wz_max: 0.7
+      iteration_count: 1
+      prune_distance: 1.8
       transform_tolerance: 0.25
-      temperature: 0.25
+      temperature: 0.3
       gamma: 0.015
       motion_model: DiffDrive
       visualize: false
@@ -181,14 +180,14 @@ controller_server:
       ObstaclesCritic:
         weight: 5.0
         consider_footprint: true
-        collision_margin_distance: 0.10   # margen realista en esquinas
+        collision_margin_distance: 0.10
 
-      PathAlignCritic:     {weight: 12.0}
-      PathFollowCritic:    {weight: 16.0}
-      GoalCritic:          {weight: 1.0}
-      PreferForwardCritic: {weight: 0.5}
-      ConstraintCritic:    {weight: 1.0}
-      TwirlingCritic:      {weight: 0.4}
+      PathAlignCritic:   {weight: 10.0}
+      PathFollowCritic:  {weight: 6.0}
+      GoalCritic:        {weight: 3.0}
+      PreferForwardCritic: {weight: 5.0}
+      ConstraintCritic:  {weight: 1.0}
+      TwirlingCritic:    {weight: 2.0}
 
 controller_server_rclcpp_node:
   ros__parameters:
@@ -207,12 +206,7 @@ local_costmap:
       width: 4
       height: 4
       resolution: 0.04
-      plugins: [static_layer, obstacle_layer, inflation_layer]
-      static_layer:
-        plugin: nav2_costmap_2d::StaticLayer
-        enabled: true
-        map_subscribe_transient_local: true
-        combination_method: Maximum
+      plugins: [obstacle_layer, inflation_layer]
       obstacle_layer:
         plugin: nav2_costmap_2d::ObstacleLayer
         enabled: true
@@ -454,7 +448,7 @@ velocity_smoother:
   ros__parameters:
     use_sim_time: false
 
-    smoothing_frequency: 20.0
+    smoothing_frequency: 5.0
     scale_velocities: false
     feedback: OPEN_LOOP
     max_velocity: [0.5, 0.0, 1.5]   # Measured: MAX[1.0, 0.0, 3.14] (decreased for safety)
@@ -463,6 +457,6 @@ velocity_smoother:
     max_decel: [-1.0, 0.0, -3.2]  # Measured
     # used in the CLOSED_LOOP feedback mode
     # odom_topic: "odometry/filtered"
-    odom_duration: 0.05
-    deadband_velocity: [0.005, 0.0, 0.02]
+    odom_duration: 0.1
+    deadband_velocity: [0.01, 0.01, 0.1] # Measured
     velocity_timeout: 1.0


### PR DESCRIPTION
## Summary
- restore the MPPI controller and velocity smoother configuration to the values that preceded the earlier update request

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f76570c3a883239a455d9334b7d89f