### PR TITLE
Restore original MPPI parameter values

### DIFF
--- a/config/nav2_mppi_params.yaml
+++ b/config/nav2_mppi_params.yaml
@@ -120,10 +120,10 @@ bt_navigator_rclcpp_node:
 controller_server:
   ros__parameters:
     use_sim_time: false
-    controller_frequency: 30.0
+    controller_frequency: 20.0
     min_x_velocity_threshold: 0.01    # Measured
     min_y_velocity_threshold: 0.01    # Measured
-    min_theta_velocity_threshold: 0.02
+    min_theta_velocity_threshold: 0.1 # Measured
     progress_checker_plugin: progress_checker
     goal_checker_plugin: goal_checker
     general_goal_checker:
@@ -154,12 +154,12 @@ controller_server:
       batch_size: 800
       vx_std: 0.2
       vy_std: 0.0
-      wz_std: 0.55
+      wz_std: 0.35
       vx_max: 0.3
       vx_min: -0.2
       vy_max: 0.0
-      wz_max: 1.1
-      iteration_count: 2
+      wz_max: 0.7
+      iteration_count: 1
       prune_distance: 1.8
       transform_tolerance: 0.25
       temperature: 0.3
@@ -187,7 +187,7 @@ controller_server:
       GoalCritic:        {weight: 3.0}
       PreferForwardCritic: {weight: 5.0}
       ConstraintCritic:  {weight: 1.0}
-      TwirlingCritic:    {weight: 0.5}
+      TwirlingCritic:    {weight: 2.0}
 
 controller_server_rclcpp_node:
   ros__parameters:
@@ -448,7 +448,7 @@ velocity_smoother:
   ros__parameters:
     use_sim_time: false
 
-    smoothing_frequency: 15.0
+    smoothing_frequency: 5.0
     scale_velocities: false
     feedback: OPEN_LOOP
     max_velocity: [0.5, 0.0, 1.5]   # Measured: MAX[1.0, 0.0, 3.14] (decreased for safety)
@@ -457,6 +457,6 @@ velocity_smoother:
     max_decel: [-1.0, 0.0, -3.2]  # Measured
     # used in the CLOSED_LOOP feedback mode
     # odom_topic: "odometry/filtered"
-    odom_duration: 0.05
-    deadband_velocity: [0.005, 0.005, 0.02]
+    odom_duration: 0.1
+    deadband_velocity: [0.01, 0.01, 0.1] # Measured
     velocity_timeout: 1.0


### PR DESCRIPTION
## Summary
- restore the MPPI controller configuration to the previous frequency, yaw threshold, and noise parameters
- revert the TwirlingCritic weight and reset the velocity smoother timing and deadband values

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f8ccc87d348323bdaecfa486c0ab7c