### PR TITLE
Fix Nav2 goal checker stateful configuration

### DIFF
--- a/config/nav2_mppi_params.yaml
+++ b/config/nav2_mppi_params.yaml
@@ -126,11 +126,12 @@ controller_server:
     min_theta_velocity_threshold: 0.1 # Measured
     progress_checker_plugin: progress_checker
     goal_checker_plugin: goal_checker
+    current_goal_checker: goal_checker
     general_goal_checker:
       plugin: "nav2_controller::SimpleGoalChecker"
       xy_goal_tolerance: 0.35
       yaw_goal_tolerance: 0.35
-      stateful: false
+      stateful: true
     controller_plugins: [FollowPath]
 
     # Progress checker parameters
@@ -144,7 +145,7 @@ controller_server:
       plugin: nav2_controller::SimpleGoalChecker
       xy_goal_tolerance: 0.35
       yaw_goal_tolerance: 0.35
-      stateful: false
+      stateful: true
 
     # MPPI controller
     FollowPath:


### PR DESCRIPTION
## Summary
- set the Nav2 controller server to use the configured goal checker explicitly
- require the SimpleGoalChecker to be stateful so navigation does not finish immediately when starting within tolerance

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f8d6f9921083239398ba602ec1237d