### PR TITLE
Force NavigateThroughPoses to use custom behavior tree

### DIFF
--- a/scripts/bt/ntp_force_follow.xml
+++ b/scripts/bt/ntp_force_follow.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<root main_tree_to_execute="MainTree">
+  <!--
+    BT minimalista para NavigateThroughPoses que:
+    - NO evalúa GoalReached al inicio (evita "éxito instantáneo" cuando start==goal)
+    - Siempre computa un path que pase por todas las poses y lo sigue
+    - Incluye una recuperación básica de limpieza de costmaps
+  -->
+  <BehaviorTree ID="MainTree">
+    <PipelineSequence name="ntp_force_follow">
+      <RateController hz="5.0">
+        <RecoveryNode number_of_retries="3" name="recovery">
+          <Sequence name="plan_and_follow">
+            <!-- 'goals' es el vector de poses de NTP; 'path' la salida global -->
+            <ComputePathThroughPoses goals="{goals}" path="{path}"/>
+            <FollowPath path="{path}"/>
+            <!-- Quita los goals ya pasados; mantiene la tubería operativa -->
+            <RemovePassedGoals input_goals="{goals}" output_goals="{goals}" min_distance="0.10"/>
+          </Sequence>
+          <Sequence name="clear_costmaps">
+            <ClearCostmapService service_name="local_costmap/clear_entirely_local_costmap"/>
+            <ClearCostmapService service_name="global_costmap/clear_entirely_global_costmap"/>
+            <Wait seconds="0.5"/>
+          </Sequence>
+        </RecoveryNode>
+      </RateController>
+    </PipelineSequence>
+  </BehaviorTree>
+</root>
+

--- a/scripts/nav_through_poses.py
+++ b/scripts/nav_through_poses.py
@@ -5,6 +5,7 @@ from rclpy.action import ActionClient
 from geometry_msgs.msg import PoseStamped, Quaternion
 from builtin_interfaces.msg import Time as TimeMsg
 from nav2_msgs.action import NavigateThroughPoses
+import os
 
 
 def q_from_yaw(yaw: float):
@@ -47,7 +48,14 @@ class NTPClient(Node):
 
         goal = NavigateThroughPoses.Goal()
         goal.poses = self._poses
-        goal.behavior_tree = ""  # usa BT por defecto de NTP del bringup
+        # Fuerza un BT que no hace GoalReached al principio (evita éxito instantáneo)
+        bt_file = "/scripts/bt/ntp_force_follow.xml"
+        if os.path.exists(bt_file):
+            goal.behavior_tree = bt_file
+            self.get_logger().info(f"Usando BT NTP forzado: {bt_file}")
+        else:
+            goal.behavior_tree = ""  # fallback: BT por defecto
+            self.get_logger().warn("BT forzado no encontrado; usando BT por defecto")
 
         self.get_logger().info("🚀  Enviando acción /navigate_through_poses …")
         sfut = self._ac.send_goal_async(goal, feedback_callback=self._on_feedback)


### PR DESCRIPTION
## Summary
- add a dedicated behavior tree that always follows the full pose sequence and retries with costmap clears
- update nav_through_poses.py to request the custom tree for each NavigateThroughPoses goal

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f8e1ae1be0832389d95241f3a48769