### PR TITLE
Enable stateful goal checker for MPPI controller

### DIFF
--- a/config/nav2_mppi_params.yaml
+++ b/config/nav2_mppi_params.yaml
@@ -130,7 +130,7 @@ controller_server:
       plugin: "nav2_controller::SimpleGoalChecker"
       xy_goal_tolerance: 0.35
       yaw_goal_tolerance: 0.35
-      stateful: false
+      stateful: true
     controller_plugins: [FollowPath]
 
     # Progress checker parameters
@@ -144,7 +144,7 @@ controller_server:
       plugin: nav2_controller::SimpleGoalChecker
       xy_goal_tolerance: 0.35
       yaw_goal_tolerance: 0.35
-      stateful: false
+      stateful: true
 
     # MPPI controller
     FollowPath:


### PR DESCRIPTION
## Summary
- enable stateful goal checking in the MPPI controller configuration so that Nav2 requires leaving and re-entering the tolerance region

## Testing
- not run (configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68f914430df483238f7570d63762e408