### PR TITLE
Explicitly select stateful goal checker plugins

### DIFF
--- a/config/nav2_dwb_params.yaml
+++ b/config/nav2_dwb_params.yaml
@@ -150,6 +150,8 @@ controller_server:
     failure_tolerance: 0.3
     progress_checker_plugin: progress_checker
     goal_checker_plugins: [general_goal_checker]   # "precise_goal_checker"
+    # Selecciona explícitamente el plugin de goal checker activo y quita el warning
+    current_goal_checker: general_goal_checker
     controller_plugins: [FollowPath]
 
     # Progress checker parameters

--- a/config/nav2_dwb_webots_params.yaml
+++ b/config/nav2_dwb_webots_params.yaml
@@ -150,6 +150,8 @@ controller_server:
     failure_tolerance: 0.3
     progress_checker_plugin: progress_checker
     goal_checker_plugins: [general_goal_checker]   # "precise_goal_checker"
+    # Selecciona explícitamente el plugin de goal checker activo y quita el warning
+    current_goal_checker: general_goal_checker
     controller_plugins: [FollowPath]
 
     # Progress checker parameters

--- a/config/nav2_mppi_params.yaml
+++ b/config/nav2_mppi_params.yaml
@@ -126,6 +126,8 @@ controller_server:
     min_theta_velocity_threshold: 0.1 # Measured
     progress_checker_plugin: progress_checker
     goal_checker_plugin: goal_checker
+    # Selecciona explícitamente el plugin de goal checker activo y quita el warning
+    current_goal_checker: goal_checker
     general_goal_checker:
       plugin: "nav2_controller::SimpleGoalChecker"
       xy_goal_tolerance: 0.35


### PR DESCRIPTION
## Summary
- explicitly select the goal checker plugin in the MPPI controller configuration to remove startup warnings
- apply the same selection to the DWB controller configurations to keep behavior consistent

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f91a9df7248323ab89c7cf00dd73f9