### PR TITLE
Ensure stateful goal checker is selected in Nav2 configs

### DIFF
--- a/config/nav2_dwb_params.yaml
+++ b/config/nav2_dwb_params.yaml
@@ -149,9 +149,9 @@ controller_server:
     min_theta_velocity_threshold: 0.001
     failure_tolerance: 0.3
     progress_checker_plugin: progress_checker
-    goal_checker_plugins: [general_goal_checker]   # "precise_goal_checker"
-    # Selecciona explícitamente el plugin de goal checker activo y quita el warning
-    current_goal_checker: general_goal_checker
+    goal_checker_plugins: [general_goal_checker, goal_checker]   # "precise_goal_checker"
+    # Selecciona explícitamente el goal checker activo
+    current_goal_checker: goal_checker
     controller_plugins: [FollowPath]
 
     # Progress checker parameters
@@ -166,10 +166,15 @@ controller_server:
     #  yaw_goal_tolerance: 0.25
     #  stateful: True
     general_goal_checker:
-      stateful: true
       plugin: nav2_controller::SimpleGoalChecker
       xy_goal_tolerance: 0.50
       yaw_goal_tolerance: 0.60
+      stateful: true
+    goal_checker:
+      plugin: "nav2_controller::SimpleGoalChecker"
+      xy_goal_tolerance: 0.35
+      yaw_goal_tolerance: 0.35
+      stateful: true
     # DWB parameters
     FollowPath:
       plugin: dwb_core::DWBLocalPlanner

--- a/config/nav2_dwb_webots_params.yaml
+++ b/config/nav2_dwb_webots_params.yaml
@@ -149,9 +149,9 @@ controller_server:
     min_theta_velocity_threshold: 0.001
     failure_tolerance: 0.3
     progress_checker_plugin: progress_checker
-    goal_checker_plugins: [general_goal_checker]   # "precise_goal_checker"
-    # Selecciona explícitamente el plugin de goal checker activo y quita el warning
-    current_goal_checker: general_goal_checker
+    goal_checker_plugins: [general_goal_checker, goal_checker]   # "precise_goal_checker"
+    # Selecciona explícitamente el goal checker activo
+    current_goal_checker: goal_checker
     controller_plugins: [FollowPath]
 
     # Progress checker parameters
@@ -166,10 +166,15 @@ controller_server:
     #  yaw_goal_tolerance: 0.25
     #  stateful: True
     general_goal_checker:
-      stateful: true
       plugin: nav2_controller::SimpleGoalChecker
       xy_goal_tolerance: 0.2
       yaw_goal_tolerance: 0.2
+      stateful: true
+    goal_checker:
+      plugin: "nav2_controller::SimpleGoalChecker"
+      xy_goal_tolerance: 0.2
+      yaw_goal_tolerance: 0.2
+      stateful: true
     # DWB parameters
     FollowPath:
       plugin: dwb_core::DWBLocalPlanner

--- a/config/nav2_mppi_params.yaml
+++ b/config/nav2_mppi_params.yaml
@@ -126,7 +126,7 @@ controller_server:
     min_theta_velocity_threshold: 0.1 # Measured
     progress_checker_plugin: progress_checker
     goal_checker_plugin: goal_checker
-    # Selecciona explícitamente el plugin de goal checker activo y quita el warning
+    # Selecciona explícitamente el goal checker activo
     current_goal_checker: goal_checker
     general_goal_checker:
       plugin: "nav2_controller::SimpleGoalChecker"

--- a/config/nav2_mppi_webots_params.yaml
+++ b/config/nav2_mppi_webots_params.yaml
@@ -125,6 +125,8 @@ controller_server:
     min_theta_velocity_threshold: 0.1 # Measured
     progress_checker_plugin: progress_checker
     goal_checker_plugin: goal_checker
+    # Selecciona explícitamente el goal checker activo
+    current_goal_checker: goal_checker
     controller_plugins: [FollowPath]
 
     # Progress checker parameters


### PR DESCRIPTION
## Summary
- explicitly set the active goal checker in the MPPI and DWB controller configurations
- register a stateful SimpleGoalChecker plugin so "goal_checker" can be queried at runtime
- extend the Webots variants of the Nav2 configs with the same goal-checker selection

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f9201d20f8832397318e3bce88f9ac