### PR TITLE
Add optional BT support for Nav2 waypoint playback

### DIFF
--- a/justfile
+++ b/justfile
@@ -237,7 +237,8 @@ play-ntp name:
         bash -c "source /opt/ros/humble/setup.bash && \
                  python3 /scripts/nav_through_poses.py \
                  --file /routes/{{name}}.yaml \
-                 --pre auto --force-stateful"
+                 --pre auto --force-stateful \
+                 --bt /ros2_ws/bt/ntp_no_early_goal.xml"
 # ────────────────────────────────────────────────────────────────
 #  start-route  →  Arranca ROSbot con mapa fijo y reproduce una ruta
 #     Uso:  just start-route mi_ruta        # (omite la extensión .yaml)
@@ -292,6 +293,8 @@ start-ntp ruta="mi_ruta":
 
     # 2c) Verifica que los costmaps están suscritos a /scan_filtered
     @docker compose exec navigation bash -lc 'python3 /ros2_ws/scripts/nav2_guard.py'
+    # 2d) Instala BT mínimo para NTP (evita éxito inmediato al inicio)
+    @docker compose exec navigation bash -lc $'python3 - <<"PY"\nfrom pathlib import Path\nbt_dir = Path("/ros2_ws/bt")\nbt_dir.mkdir(parents=True, exist_ok=True)\n(bt_dir / "ntp_no_early_goal.xml").write_text("<root main_tree_to_execute=\"MainTree\">\n  <BehaviorTree ID=\"MainTree\">\n    <Sequence name=\"ntp_no_early_goal\">\n      <ComputePathThroughPoses goals=\"{goals}\" path=\"{path}\"/>\n      <FollowPath path=\"{path}\"/>\n      <GoalReached/>\n    </Sequence>\n  </BehaviorTree>\n</root>\n")\nPY'
 
     # 3) Lanza NTP dentro de path_tools
     @just play-ntp {{ruta}}

--- a/scripts/nav_through_poses.py
+++ b/scripts/nav_through_poses.py
@@ -30,6 +30,7 @@ class NTPClient(Node):
         detect_xy: float = 0.30,
         detect_yaw: float = 0.35,
         force_stateful: bool = True,
+        bt_file: str = "",
     ):
         super().__init__("nav_through_poses_client")
         self._shutdown_called = False
@@ -40,6 +41,7 @@ class NTPClient(Node):
         self._premove_dist = premove_dist
         self._detect_xy = detect_xy
         self._detect_yaw = detect_yaw
+        self._bt_file = bt_file
         self.get_logger().info(f"Leyendo {yaml_file} – {len(self._poses)} puntos (NTP)")
         if force_stateful:
             self._ensure_stateful_goalchecker()
@@ -72,7 +74,8 @@ class NTPClient(Node):
 
         goal = NavigateThroughPoses.Goal()
         goal.poses = self._poses
-        goal.behavior_tree = ""  # usa BT por defecto de NTP del bringup
+        # Si nos pasan un BT, úsalo; si no, deja el del bringup
+        goal.behavior_tree = self._bt_file if self._bt_file else ""
 
         self.get_logger().info("🚀  Enviando acción /navigate_through_poses …")
         sfut = self._ac_ntp.send_goal_async(goal, feedback_callback=self._on_feedback)
@@ -236,6 +239,11 @@ def main():
     ap.add_argument("--detect-xy", type=float, default=0.30)
     ap.add_argument("--detect-yaw", type=float, default=0.35)
     ap.add_argument(
+        "--bt",
+        default="",
+        help="Ruta absoluta a un BT .xml (opcional) para NTP",
+    )
+    ap.add_argument(
         "--force-stateful",
         action="store_true",
         default=True,
@@ -251,6 +259,7 @@ def main():
         detect_xy=args.detect_xy,
         detect_yaw=args.detect_yaw,
         force_stateful=args.force_stateful,
+        bt_file=args.bt,
     )
     # Ctrl-C → cancelación limpia sin 'double shutdown'
     signal.signal(signal.SIGINT, lambda *_: node._safe_shutdown())


### PR DESCRIPTION
## Summary
- add an optional `--bt` flag to `nav_through_poses.py` and forward the value to the NavigateThroughPoses goal
- update the automation in the justfile to install a minimal Nav2 BT inside the navigation container and pass its path when running NTP

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f9f22f37448323a27fc588359cebc4