### PR TITLE
Improve NTP startup robustness and goal tolerances

### DIFF
--- a/config/nav2_dwb_params.yaml
+++ b/config/nav2_dwb_params.yaml
@@ -169,13 +169,13 @@ controller_server:
     # SimpleGoalChecker
     general_goal_checker:
       plugin: "nav2_controller::SimpleGoalChecker"
-      xy_goal_tolerance: 0.35
-      yaw_goal_tolerance: 0.35
+      xy_goal_tolerance: 0.08
+      yaw_goal_tolerance: 0.15
       stateful: true
     goal_checker:
       plugin: "nav2_controller::SimpleGoalChecker"
-      xy_goal_tolerance: 0.35
-      yaw_goal_tolerance: 0.35
+      xy_goal_tolerance: 0.08
+      yaw_goal_tolerance: 0.15
       stateful: true
     # DWB parameters
     FollowPath:

--- a/config/nav2_dwb_webots_params.yaml
+++ b/config/nav2_dwb_webots_params.yaml
@@ -167,13 +167,13 @@ controller_server:
     #  stateful: True
     general_goal_checker:
       plugin: nav2_controller::SimpleGoalChecker
-      xy_goal_tolerance: 0.2
-      yaw_goal_tolerance: 0.2
+      xy_goal_tolerance: 0.08
+      yaw_goal_tolerance: 0.15
       stateful: true
     goal_checker:
       plugin: "nav2_controller::SimpleGoalChecker"
-      xy_goal_tolerance: 0.2
-      yaw_goal_tolerance: 0.2
+      xy_goal_tolerance: 0.08
+      yaw_goal_tolerance: 0.15
       stateful: true
     # DWB parameters
     FollowPath:

--- a/config/nav2_mppi_params.yaml
+++ b/config/nav2_mppi_params.yaml
@@ -131,8 +131,8 @@ controller_server:
     # SimpleGoalChecker
     general_goal_checker:
       plugin: "nav2_controller::SimpleGoalChecker"
-      xy_goal_tolerance: 0.35
-      yaw_goal_tolerance: 0.35
+      xy_goal_tolerance: 0.08
+      yaw_goal_tolerance: 0.15
       stateful: true
     controller_plugins: [FollowPath]
 
@@ -145,8 +145,8 @@ controller_server:
     # Goal checker parameters
     goal_checker:
       plugin: nav2_controller::SimpleGoalChecker
-      xy_goal_tolerance: 0.35
-      yaw_goal_tolerance: 0.35
+      xy_goal_tolerance: 0.08
+      yaw_goal_tolerance: 0.15
       stateful: true
 
     # MPPI controller

--- a/config/nav2_mppi_webots_params.yaml
+++ b/config/nav2_mppi_webots_params.yaml
@@ -138,8 +138,8 @@ controller_server:
     # Goal checker parameters
     goal_checker:
       plugin: nav2_controller::SimpleGoalChecker
-      xy_goal_tolerance: 0.15
-      yaw_goal_tolerance: 0.25
+      xy_goal_tolerance: 0.08
+      yaw_goal_tolerance: 0.15
       stateful: true
 
     # MPPI controller

--- a/config/nav2_rpp_params.yaml
+++ b/config/nav2_rpp_params.yaml
@@ -137,13 +137,13 @@ controller_server:
     goal_checker_plugin: goal_checker
     general_goal_checker:
       plugin: "nav2_controller::SimpleGoalChecker"
-      xy_goal_tolerance: 0.35
-      yaw_goal_tolerance: 0.35
+      xy_goal_tolerance: 0.08
+      yaw_goal_tolerance: 0.15
       stateful: false
     goal_checker:
       plugin: nav2_controller::SimpleGoalChecker
-      xy_goal_tolerance: 0.35
-      yaw_goal_tolerance: 0.35
+      xy_goal_tolerance: 0.08
+      yaw_goal_tolerance: 0.15
       stateful: false # if stateful is True goal checker will not check if the xy position matches again once it is found to be True.
 
     controller_plugins: [FollowPath]

--- a/config/nav2_rpp_webots_params.yaml
+++ b/config/nav2_rpp_webots_params.yaml
@@ -137,8 +137,8 @@ controller_server:
     goal_checker_plugin: goal_checker
     goal_checker:
       plugin: nav2_controller::SimpleGoalChecker
-      xy_goal_tolerance: 0.1
-      yaw_goal_tolerance: 0.3
+      xy_goal_tolerance: 0.08
+      yaw_goal_tolerance: 0.15
       stateful: true # if stateful is True goal checker will not check if the xy position matches again once it is found to be True.
 
     controller_plugins: [FollowPath]

--- a/justfile
+++ b/justfile
@@ -293,13 +293,13 @@ start-ntp ruta="mi_ruta":
 
     # 2c) Verifica que los costmaps están suscritos a /scan_filtered
     @docker compose exec navigation bash -lc 'python3 /ros2_ws/scripts/nav2_guard.py'
-    # 2d) Instala BT mínimo para NTP (evita éxito inmediato al inicio)
+    # 2d) Espera a TF base_link→odom antes de lanzar el script
+    @docker compose exec navigation bash -lc 'source /opt/ros/humble/setup.bash && python3 /ros2_ws/scripts/wait_for_tf.py odom base_link --timeout 30'
+    # 2e) Instala BT mínimo para NTP (evita éxito inmediato al inicio)
     @docker compose exec navigation python3 -c 'from pathlib import Path; bt_dir = Path("/ros2_ws/bt"); bt_dir.mkdir(parents=True, exist_ok=True); bt_dir.joinpath("ntp_no_early_goal.xml").write_text("""<root main_tree_to_execute="MainTree">\n  <BehaviorTree ID="MainTree">\n    <Sequence name="ntp_no_early_goal">\n      <ComputePathThroughPoses goals="{goals}" path="{path}"/>\n      <FollowPath path="{path}"/>\n      <GoalReached/>\n    </Sequence>\n  </BehaviorTree>\n</root>\n""")'
 
     # 3) Lanza NTP dentro de path_tools
     @just play-ntp {{ruta}}
-
-    @printf $'5) Afinados recomendados (opcionales)\n\nTolerancias: si quieres hacerlo "más difícil" de cantar meta (incluso con el BT mínimo), baja tolerancias en tus YAML (xy_goal_tolerance: 0.08, yaw_goal_tolerance: 0.15) en ambos plugins (goal_checker y general_goal_checker). Esto no es imprescindible con el BT, pero endurece el cierre.\n\nTF al arranque: los avisos de Timed out waiting for transform base_link→odom sólo al inicio son normales, pero si quieres evitar sustos, puedes añadir una espera activa a TF en start-ntp antes de lanzar el script (igual que ya esperas a las acciones). Tu layout y herramientas ya pintan /plan, /unsmoothed_plan, /goal_pose, etc., así que es fácil ver que está funcionando.\n'
 
 # ────────────────────────────────────────────────────────────────
 #  ruta1  →  atajo sin parámetros. Equivale a:

--- a/scripts/wait_for_tf.py
+++ b/scripts/wait_for_tf.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Active wait for a transform before starting Nav2 tooling."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import Optional
+
+import rclpy
+from rclpy.duration import Duration
+from rclpy.node import Node
+from tf2_ros import Buffer, ConnectivityException, ExtrapolationException, LookupException, TransformListener
+
+
+class TFWaiter(Node):
+    """Spin until a transform between two frames becomes available."""
+
+    def __init__(self, target_frame: str, source_frame: str) -> None:
+        super().__init__("wait_for_tf")
+        self._target_frame = target_frame
+        self._source_frame = source_frame
+        self._buffer = Buffer()
+        self._listener = TransformListener(self._buffer, self)
+
+    def wait(self, timeout: float) -> bool:
+        deadline: Optional[Duration] = None if timeout <= 0 else Duration(seconds=float(timeout))
+        start_time = self.get_clock().now()
+        self.get_logger().info(
+            "Esperando TF %s → %s (timeout %.1f s)...",
+            self._source_frame,
+            self._target_frame,
+            timeout,
+        )
+        while rclpy.ok():
+            rclpy.spin_once(self, timeout_sec=0.1)
+            try:
+                self._buffer.lookup_transform(
+                    self._target_frame,
+                    self._source_frame,
+                    rclpy.time.Time(),
+                )
+                self.get_logger().info(
+                    "TF %s → %s disponible.", self._source_frame, self._target_frame
+                )
+                return True
+            except (LookupException, ConnectivityException, ExtrapolationException):
+                if deadline is not None and self.get_clock().now() - start_time > deadline:
+                    break
+        self.get_logger().error(
+            "TF %s → %s no disponible tras %.1f s.",
+            self._source_frame,
+            self._target_frame,
+            timeout,
+        )
+        return False
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("target_frame", help="Target frame (e.g. odom)")
+    parser.add_argument("source_frame", help="Source frame (e.g. base_link)")
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=30.0,
+        help="Timeout in seconds (<=0 to wait forever)",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = parse_args(argv if argv is not None else sys.argv[1:])
+
+    rclpy.init()
+    node = TFWaiter(args.target_frame, args.source_frame)
+    try:
+        success = node.wait(args.timeout)
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+    return 0 if success else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- tighten the goal checker tolerances to 0.08 m / 0.15 rad across the Nav2 parameter profiles
- add a reusable wait_for_tf helper and use it in the start-ntp recipe to block until base_link→odom is available

## Testing
- python3 -m compileall scripts/wait_for_tf.py

------
https://chatgpt.com/codex/tasks/task_e_68f9fa25b7608323a6a855025b1d0302