### PR TITLE
Set nav stack containers to host networking

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -41,13 +41,16 @@ services:
   rplidar:
     image: husarion/rplidar:humble-1.0.1-20240104
     restart: unless-stopped
+    # RECOMENDADO: ponerlo también en host para simplificar descubrimiento
+    network_mode: host
     devices:
       - ${RPLIDAR_BYID:-/dev/ttyUSB0}:/dev/rplidar
     command: >
       ros2 launch /husarion_utils/rplidar.launch.py
         serial_port:=${RPLIDAR_PORT:-/dev/rplidar}
         serial_baudrate:=${LIDAR_BAUDRATE:-1000000}
-    environment: [ ROS_DOMAIN_ID=0 ]
+    environment:
+      - ROS_DOMAIN_ID=${ROS_DOMAIN_ID:-0}
     healthcheck:
       test: ["CMD-SHELL",
              "bash -c 'source /opt/ros/humble/setup.bash && ros2 topic list | grep -q ^/scan$'"]
@@ -59,6 +62,8 @@ services:
   navigation:
     image: husarion/navigation2:humble-1.1.12-20240123
     restart: unless-stopped
+    # <-- ESTE ES EL CAMBIO CRÍTICO
+    network_mode: host
     depends_on:
       rplidar: { condition: service_started }
       rosbot:  { condition: service_started }
@@ -67,6 +72,7 @@ services:
       - ./maps:/maps
       - ./scripts:/ros2_ws/scripts:ro
     environment:
+      - ROS_DOMAIN_ID=${ROS_DOMAIN_ID:-0}
       - MAP=${MAP:-r1}
     command: >
       ros2 launch /husarion_utils/bringup_launch.py
@@ -77,9 +83,10 @@ services:
 
   path_tools:
     image: husarion/navigation2:humble-1.1.12-20240123
-    network_mode: host
+    network_mode: host              # para que vea a /navigate_through_poses sin fricción
     restart: unless-stopped
-    environment: [ ROS_DOMAIN_ID=0 ]
+    environment:
+      - ROS_DOMAIN_ID=${ROS_DOMAIN_ID:-0}
     volumes:
       - ./routes:/routes
       - ./scripts:/scripts:ro


### PR DESCRIPTION
## Summary
- run rplidar, navigation, and path_tools services in host networking mode for easier DDS discovery
- propagate configurable ROS_DOMAIN_ID for these services while keeping map selection support

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fa67732730832395114b2dcfc537db